### PR TITLE
style: adding all SSA branding colours to global.css

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -8,12 +8,12 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-SSA-red: #f85b76;
-  --color-SSA-red-light: #FF879C;
-  --color-SSA-yellow: #ffe6b6;
-  --color-SSA-yellow-light: #FFF7E9;
-  --color-SSA-white: #fefcf9;
-  --color-SSA-black: #0A0805;
+  --color-ssa-red: #f85b76;
+  --color-ssa-red-light: #ff879c;
+  --color-ssa-yellow: #ffe6b6;
+  --color-ssa-yellow-light: #fff7e9;
+  --color-ssa-white: #fefcf9;
+  --color-ssa-black: #0a0805;
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -8,6 +8,12 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-SSA-red: #f85b76;
+  --color-SSA-red-light: #FF879C;
+  --color-SSA-yellow: #ffe6b6;
+  --color-SSA-yellow-light: #FFF7E9;
+  --color-SSA-white: #fefcf9;
+  --color-SSA-black: #0A0805;
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }


### PR DESCRIPTION
## What does this PR do?
Added the SSA brand colours as per Figma for reuse

## Type of change
- [ ] Feature
- [ ] Bug fix
- [X] Chore / config
- [ ] Hotfix

## Checklist
- [X] My branch follows the naming convention (`feature/`, `fix/`, `chore/`, `hotfix/`)
- [X] My commit messages follow the conventional commits format
- [X] CI checks pass

## Linked issues
#11 

## Notes:
Use them in Tailwind classes as:
- `text-ssa-red`, `bg-ssa-red`, `border-ssa-red`
- `text-ssa-yellow`, `bg-ssa-yellow`, `border-ssa-yellow`
- `text-ssa-white`, `bg-ssa-white`, `border-ssa-white`

Opacity variants also work, e.g. `text-ssa-red/80`, `bg-ssa-red/90`.