### PR TITLE
chore: update CI and add docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate:
-    name: Validate branch & commits
+    name: Validate branch name
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -20,28 +20,6 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check commit messages
-        run: |
-          COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --format="%s" --no-merges)
-          PATTERN="^(feat|fix|chore|hotfix|docs|refactor|test|style|ci)(\(.+\))?: .+"
-          FAILED=0
-          while IFS= read -r msg; do
-            if [ -z "$msg" ]; then continue; fi
-            if ! echo "$msg" | grep -qE "$PATTERN"; then
-              echo "Invalid commit message: '$msg'"
-              FAILED=1
-            fi
-          done <<< "$COMMITS"
-          if [ $FAILED -eq 1 ]; then
-            echo ""
-            echo "Commit messages must follow: type(scope): description"
-            echo "Valid types: feat, fix, chore, hotfix, docs, refactor, test, style, ci"
-            exit 1
-          fi
 
   web:
     name: Web

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,86 @@
+# Architecture
+
+## Repo structure
+
+The repo contains two Next.js apps that are built and deployed together as a single container:
+
+```
+ssa/
+├── web/        # Next.js 16 public-facing website
+├── cms/        # Payload CMS 3.0 admin + content API
+├── Dockerfile  # Multi-stage build combining both apps
+├── nginx.conf  # Reverse proxy routing
+└── fly.toml    # Fly.io deployment config
+```
+
+There are no shared packages — the web app consumes content from the CMS via its REST/GraphQL API at runtime.
+
+## System components
+
+```mermaid
+graph TD
+    subgraph Browser
+        USER[Visitor / Admin]
+    end
+
+    subgraph Fly.io ["Fly.io (Sydney)"]
+        NGINX[Nginx :80]
+        WEB[Web app<br/>Next.js 16 :3000]
+        CMS[CMS<br/>Payload 3.0 :3001]
+    end
+
+    subgraph External
+        DB[(PostgreSQL)]
+    end
+
+    USER -->|HTTPS| NGINX
+    NGINX -->|"/ (everything else)"| WEB
+    NGINX -->|"/admin, /api"| CMS
+    WEB -->|Payload REST / GraphQL API| CMS
+    CMS --> DB
+```
+
+## Request routing
+
+Nginx is the single entry point. All traffic hits port 80 (force-HTTPS on Fly.io), and is routed by path prefix:
+
+```mermaid
+graph TD
+    REQ[Incoming request] --> CHECK{Path prefix?}
+    CHECK -->|"/admin/*"| CMS_ADMIN[CMS :3001<br/>Admin panel]
+    CHECK -->|"/api/*"| CMS_API[CMS :3001<br/>REST + GraphQL API]
+    CHECK -->|Everything else| WEB_APP[Web :3000<br/>Public website]
+```
+
+## Docker multi-stage build
+
+Both apps share a single `Dockerfile` at the repo root. They are built independently and combined into one runner image:
+
+```mermaid
+flowchart TD
+    BASE[node:22-alpine base<br/>+ nginx + pnpm]
+
+    BASE --> CMS_DEPS[cms-deps<br/>pnpm install]
+    CMS_DEPS --> CMS_BUILD[cms-builder<br/>pnpm build]
+
+    BASE --> WEB_DEPS[web-deps<br/>pnpm install]
+    WEB_DEPS --> WEB_BUILD[web-builder<br/>pnpm build]
+
+    CMS_BUILD --> RUNNER[runner image]
+    WEB_BUILD --> RUNNER
+
+    RUNNER --> START["CMD: nginx + node cms/server.js + node web/server.js"]
+```
+
+Both Next.js apps use `output: 'standalone'` so only the minimal runtime files are copied into the final image.
+
+## Technology choices
+
+| Layer      | Technology              | Why                                                      |
+| ---------- | ----------------------- | -------------------------------------------------------- |
+| Frontend   | Next.js 16 (App Router) | SSR + React Server Components                            |
+| Styling    | Tailwind CSS 4          | Utility-first                                            |
+| CMS        | Payload 3.0             | Code-first CMS, runs as a Next.js app, type-safe         |
+| Database   | PostgreSQL              | Payload's postgres adapter; hosted externally            |
+| Proxy      | Nginx                   | Routes `/admin` + `/api` to CMS, everything else to web  |
+| Deployment | Fly.io                  | Single container, Sydney region (`syd`), 256 MB RAM      |

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,77 @@
+# CI/CD
+
+## Overview
+
+There are three GitHub Actions workflows in `.github/workflows/`:
+
+| Workflow               | Trigger                        | What it does                              |
+| ---------------------- | ------------------------------ | ----------------------------------------- |
+| `ci.yml`               | Every PR + push to `main`      | Lint, typecheck, build both apps          |
+| `fly-deploy.yml`       | Push to `main`                 | Deploy to Fly.io                          |
+| `pr-notifications.yml` | PR opened / reopened / merged  | Post Discord notification                 |
+
+## CI pipeline
+
+```mermaid
+flowchart TD
+    PUSH[Push or PR opened]
+
+    PUSH --> VALIDATE{Is it a PR?}
+    VALIDATE -->|Yes| BRANCH[Validate branch name<br/>must match feature/ fix/ chore/ hotfix/]
+    BRANCH -->|Invalid| FAIL_BRANCH[❌ Fail]
+    BRANCH -->|Valid| PARALLEL
+
+    VALIDATE -->|No - push to main| PARALLEL
+
+    PARALLEL --> WEB_JOB[Web job<br/>pnpm install → lint → format:check → tsc → build]
+    PARALLEL --> CMS_JOB[CMS job<br/>pnpm install → lint → tsc → build]
+
+    WEB_JOB -->|Pass| SUCCESS[✅ CI passed]
+    CMS_JOB -->|Pass| SUCCESS
+    WEB_JOB -->|Fail| FAIL[❌ CI failed]
+    CMS_JOB -->|Fail| FAIL
+```
+
+The web and CMS jobs run in parallel. Both must pass for CI to be green.
+
+## Deploy pipeline
+
+Deploys are triggered automatically on every push to `main`. Only one deploy runs at a time (`concurrency: deploy-group`).
+
+```mermaid
+flowchart TD
+    MAIN[Push to main]
+    MAIN --> BUILD[flyctl deploy --remote-only<br/>Fly.io builds the Docker image remotely]
+    BUILD --> DEPLOY[Rolling deploy to Fly.io<br/>app: ssa-prod · region: syd]
+    DEPLOY --> LIVE[✅ Live]
+```
+
+`--remote-only` means the Docker build runs on Fly.io's infrastructure, not in the GitHub Actions runner — no large image transfer required.
+
+## PR notifications
+
+When a PR is opened, reopened, or merged, a Discord webhook posts a message to the team channel.
+
+```mermaid
+sequenceDiagram
+    participant GitHub
+    participant GitHub Actions
+    participant Discord
+
+    GitHub->>GitHub Actions: PR opened / reopened
+    GitHub Actions->>Discord: "Pull request opened: [title] | [link]"
+
+    GitHub->>GitHub Actions: PR merged
+    GitHub Actions->>Discord: "Pull request merged: [title]"
+```
+
+The webhook URL is stored as the `DISCORD_WEBHOOK_URL` repository secret.
+
+## Required secrets
+
+| Secret               | Used by              | Purpose                             |
+| -------------------- | -------------------- | ----------------------------------- |
+| `PAYLOAD_SECRET`     | `ci.yml` (CMS build) | Required to build the CMS           |
+| `DATABASE_URL`       | `ci.yml` (CMS build) | Required to build the CMS           |
+| `FLY_API_TOKEN`      | `fly-deploy.yml`     | Authenticates with Fly.io           |
+| `DISCORD_WEBHOOK_URL`| `pr-notifications.yml` | Posts messages to Discord         |

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,130 @@
+# Database
+
+## Overview
+
+The database is PostgreSQL, managed by [Payload CMS](https://payloadcms.com) using the `@payloadcms/db-postgres` adapter. The schema is defined through Payload collection configs in `cms/src/collections/` and registered in `cms/src/payload.config.ts`. Payload handles migrations automatically.
+
+The generated TypeScript types live in `cms/src/payload-types.ts` — regenerate them after any schema change:
+
+```bash
+cd cms
+pnpm generate:types
+```
+
+## Collections
+
+```mermaid
+graph TD
+    A["Auth Collections<br/>Users · Members"] --> DB
+    B["Content Collections<br/>Events · Execs · Sponsors"] --> DB
+    C["Media<br/>Media"] --> DB
+    D["Payload System<br/>payload-kv · payload-locked-documents<br/>payload-preferences · payload-migrations"] --> DB
+    DB[("PostgreSQL")]
+```
+
+### Auth collections
+
+**`users`** — Payload admin accounts. Email/password auth is built in. Anyone with a user account can access the `/admin` panel.
+
+**`members`** — SSA member accounts. Email/password auth enabled. Separate from admin users — members do not have CMS admin access.
+
+### Content collections
+
+**`events`** — Events displayed on the public site. Read-only from the web app's perspective; managed by admins in the CMS.
+
+**`execs`** — Executive committee members displayed on the About page.
+
+**`sponsors`** — Sponsors displayed on the Sponsors page, with one optionally highlighted as sponsor of the week.
+
+### Media
+
+**`media`** — All uploaded files (images, etc.). Used by Events (cover image + gallery), Execs (photo), and Sponsors (logo). Every upload requires an `alt` text field.
+
+## Schema
+
+```mermaid
+erDiagram
+    users {
+        int id PK
+        string email
+        string password
+    }
+
+    members {
+        int id PK
+        string name
+        string email
+        string password
+        string phone
+        enum membershipStatus "active | expired | pending"
+        date membershipExpiry
+        string stripeCustomerId
+        string emergencyContactName
+        string emergencyContactPhone
+    }
+
+    events {
+        int id PK
+        string title
+        date date
+        richtext description
+        int coverImage FK
+        boolean isUpcoming
+    }
+
+    event_images {
+        int id PK
+        int eventId FK
+        int mediaId FK
+    }
+
+    execs {
+        int id PK
+        string name
+        string role
+        int photo FK
+        text bio
+        int year
+    }
+
+    sponsors {
+        int id PK
+        string name
+        int logo FK
+        string websiteUrl
+        boolean isSponsorOfTheWeek
+        text description
+    }
+
+    media {
+        int id PK
+        string alt
+        string url
+        string filename
+        string mimeType
+        int width
+        int height
+    }
+
+    events ||--o| media : "coverImage"
+    events ||--o{ event_images : "images"
+    event_images }o--|| media : "file"
+    execs ||--o| media : "photo"
+    sponsors ||--o| media : "logo"
+```
+
+## Environment variables
+
+| Variable         | Required | Purpose                      |
+| ---------------- | -------- | ---------------------------- |
+| `DATABASE_URL`   | Yes      | PostgreSQL connection string |
+| `PAYLOAD_SECRET` | Yes      | JWT signing secret for auth  |
+
+## Adding a new collection
+
+1. Create a new file in `cms/src/collections/` (e.g. `Events.ts`).
+2. Define the collection config and export it.
+3. Register it in `cms/src/payload.config.ts` under `collections: [...]`.
+4. Run `pnpm dev` — Payload applies the schema change automatically in development.
+5. Run `pnpm generate:types` to update `payload-types.ts`.
+6. Commit both the collection file and the updated types file.


### PR DESCRIPTION
## Summary
- Removes commit message validation from CI
- Adds `docs/` folder with Mermaid diagrams covering architecture, database schema, and CI/CD pipeline

## Test plan
- [x] Diagrams render correctly on GitHub (Mermaid is supported natively)
- [x] CI passes