### PR TITLE
chore: fix Dockerfile for pnpm workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,32 @@ FROM node:22-alpine AS base
 RUN apk add --no-cache libc6-compat nginx
 RUN npm install -g pnpm
 
-# ========== CMS ==========
-FROM base AS cms-deps
-WORKDIR /app/cms
-COPY cms/package.json cms/pnpm-lock.yaml* ./
+# ========== DEPS ==========
+# Install all workspace deps in one stage using the root lockfile
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY web/package.json ./web/
+COPY cms/package.json ./cms/
 RUN pnpm install --frozen-lockfile
 
+# ========== CMS ==========
 FROM base AS cms-builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/cms/node_modules ./cms/node_modules
+COPY cms/ ./cms/
 WORKDIR /app/cms
-COPY --from=cms-deps /app/cms/node_modules ./node_modules
-COPY cms/ .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # ========== WEB ==========
-FROM base AS web-deps
-WORKDIR /app/web
-COPY web/package.json web/pnpm-lock.yaml* ./
-RUN pnpm install --frozen-lockfile
-
 FROM base AS web-builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/web/node_modules ./web/node_modules
+COPY web/ ./web/
 WORKDIR /app/web
-COPY --from=web-deps /app/web/node_modules ./node_modules
-COPY web/ .
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 


### PR DESCRIPTION
## What does this PR do?

Fixes the broken Fly deploy caused by the pnpm workspace migration in PR #57.

## Problem

PR #57 converted the repo to a pnpm workspace, moving the lockfile to a single root-level `pnpm-lock.yaml` and deleting `web/pnpm-lock.yaml`. The Dockerfile was not updated to match, so the build was failing with:

\`\`\`
ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
\`\`\`

## Fix

Replaced the separate `cms-deps` and `web-deps` install stages with a single `deps` stage that copies the root `pnpm-lock.yaml` and `pnpm-workspace.yaml`, installs all workspace dependencies at once, then passes the resolved `node_modules` into each builder stage.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Chore / config
- [ ] Hotfix

## Checklist

- [x] My branch follows the naming convention (`feature/`, `fix/`, `chore/`, `hotfix/`)
- [x] My commit messages follow the conventional commits format
- [x] CI checks pass