### PR TITLE
fix: copy workspace manifests into builder stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN pnpm install --frozen-lockfile
 # ========== CMS ==========
 FROM base AS cms-builder
 WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY web/package.json ./web/
+COPY cms/package.json ./cms/
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/cms/node_modules ./cms/node_modules
 COPY cms/ ./cms/
@@ -25,6 +28,9 @@ RUN pnpm build
 # ========== WEB ==========
 FROM base AS web-builder
 WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY web/package.json ./web/
+COPY cms/package.json ./cms/
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/web/node_modules ./web/node_modules
 COPY web/ ./web/


### PR DESCRIPTION
## Summary
- Fixes the Fly deploy failure introduced in #58
- `pnpm` runs a `runDepsStatusCheck` before executing any script (including `pnpm build`). Without `pnpm-lock.yaml` and `pnpm-workspace.yaml` present in the builder stages, the check fails and the build aborts before Next.js compiles anything
- Adds three `COPY` lines to both `cms-builder` and `web-builder` stages to copy the workspace manifests (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` + each package's `package.json`), matching what the `deps` stage already receives

## Test plan
- [x] Fly Deploy GitHub Actions check passes (was failing with exit code 1 on `pnpm build`)
- [x] CI (ESLint, TypeScript, build) continues to pass