### PR TITLE
chore: exposed events data in the frontend

### DIFF
--- a/cms/src/collections/Events.ts
+++ b/cms/src/collections/Events.ts
@@ -2,6 +2,9 @@ import type { CollectionConfig } from 'payload'
 
 export const Events: CollectionConfig = {
   slug: 'events',
+  access: {
+    read: () => true,
+  },
   admin: {
     useAsTitle: 'title',
   },
@@ -26,6 +29,17 @@ export const Events: CollectionConfig = {
       relationTo: 'media',
     },
     {
+      name: 'category',
+      type: 'select',
+      options: [
+        { label: 'Social', value: 'social' },
+        { label: 'Cultural', value: 'cultural' },
+        { label: 'Academic', value: 'academic' },
+        { label: 'Sports', value: 'sports' },
+        { label: 'Other', value: 'other' },
+      ],
+    },
+    {
       name: 'isUpcoming',
       type: 'checkbox',
       defaultValue: true,
@@ -41,8 +55,8 @@ export const Events: CollectionConfig = {
           type: 'upload',
           relationTo: 'media',
           required: true,
-        }
+        },
       ],
-    }
-  ]
+    },
+  ],
 }

--- a/cms/src/collections/Events.ts
+++ b/cms/src/collections/Events.ts
@@ -32,11 +32,11 @@ export const Events: CollectionConfig = {
       name: 'category',
       type: 'select',
       options: [
-        { label: 'Social', value: 'social' },
-        { label: 'Cultural', value: 'cultural' },
-        { label: 'Academic', value: 'academic' },
-        { label: 'Sports', value: 'sports' },
-        { label: 'Other', value: 'other' },
+        { label: 'Games', value: 'games' },
+        { label: 'Community', value: 'community' },
+        { label: 'Food', value: 'food' },
+        { label: 'AGM', value: 'agm' },
+        { label: 'All', value: 'all' },
       ],
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
 
   web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.10
+        version: 5.100.10(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)
@@ -1705,6 +1708,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
+
+  '@tanstack/query-core@5.100.10':
+    resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
+
+  '@tanstack/react-query@5.100.10':
+    resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6173,6 +6184,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       postcss: 8.5.14
       tailwindcss: 4.2.4
+
+  '@tanstack/query-core@5.100.10': {}
+
+  '@tanstack/react-query@5.100.10(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.100.10
+      react: 19.2.3
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.10",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono, Averia_Serif_Libre } from 'next/font/google'
 import './globals.css'
 import Navbar from '@/components/Navbar'
+import { QueryProvider } from '@/providers/QueryProvider'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -36,7 +37,7 @@ export default function RootLayout({
         style={{ paddingTop: '88px' }}
       >
         <Navbar />
-        {children}
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   )

--- a/web/src/hooks/useEvents.ts
+++ b/web/src/hooks/useEvents.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchFromCMS } from '@/lib/api'
+import type { Event, EventsResponse } from '@/types/events'
+
+export const eventKeys = {
+  all: ['events'] as const,
+  lists: () => [...eventKeys.all, 'list'] as const,
+  detail: (id: number) => [...eventKeys.all, 'detail', id] as const,
+}
+
+export function useEvents() {
+  return useQuery({
+    queryKey: eventKeys.lists(),
+    queryFn: () =>
+      fetchFromCMS<EventsResponse>('/events?depth=1&limit=100&sort=-date'),
+    select: (data) => data.docs,
+  })
+}
+
+export function useUpcomingEvents() {
+  const query = useEvents()
+
+  return {
+    ...query,
+    data: query.data?.filter((event: Event) => event.isUpcoming === true) ?? [],
+  }
+}
+
+export function usePastEvents() {
+  const query = useEvents()
+
+  return {
+    ...query,
+    data: query.data?.filter((event: Event) => event.isUpcoming !== true) ?? [],
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,13 @@
+const CMS_URL = process.env.NEXT_PUBLIC_CMS_URL ?? 'http://localhost:3001'
+
+export async function fetchFromCMS<T>(path: string): Promise<T> {
+  const res = await fetch(`${CMS_URL}/api${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+  if (!res.ok) {
+    throw new Error(`CMS request failed: ${res.status} ${res.statusText}`)
+  }
+
+  return res.json() as Promise<T>
+}

--- a/web/src/providers/QueryProvider.tsx
+++ b/web/src/providers/QueryProvider.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  )
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}

--- a/web/src/types/events.ts
+++ b/web/src/types/events.ts
@@ -1,0 +1,45 @@
+export interface EventMedia {
+  id: number
+  url: string | null
+  alt: string
+  width: number | null
+  height: number | null
+}
+
+export type EventCategory =
+  | 'social'
+  | 'cultural'
+  | 'academic'
+  | 'sports'
+  | 'other'
+
+export interface EventImage {
+  id: string | null
+  image: EventMedia
+}
+
+export interface Event {
+  id: number
+  title: string
+  date: string
+  description: string | null
+  coverImage: EventMedia | null
+  category: EventCategory | null
+  isUpcoming: boolean | null
+  images: EventImage[] | null
+  updatedAt: string
+  createdAt: string
+}
+
+export interface EventsResponse {
+  docs: Event[]
+  totalDocs: number
+  limit: number
+  totalPages: number
+  page: number
+  pagingCounter: number
+  hasPrevPage: boolean
+  hasNextPage: boolean
+  prevPage: number | null
+  nextPage: number | null
+}


### PR DESCRIPTION
## What does this PR do?

Sets up the data layer for the events page. Opens public read access on the CMS `events` collection, adds a `category` field, installs TanStack Query, and ships three composable hooks (`useEvents`, `useUpcomingEvents`, `usePastEvents`) backed by a typed API client. All three hooks share one cache entry so the page makes a single network request. The events page itself is not wired up yet — this is the reusable foundation for that work.

## Type of change

- [x] Feature
- [ ] Bug fix
- [x] Chore / config
- [ ] Hotfix

## Checklist

- [x] My branch follows the naming convention (`feature/`, `fix/`, `chore/`, `hotfix/`)
- [x] My commit messages follow the conventional commits format
- [ ] CI checks pass

## Linked Issues
Closes #40 
Addresses #
Related to #
