### PR TITLE
chore: tighten CI and document pnpm-only install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,7 @@ jobs:
         env:
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - run: pnpm --filter cms test:int
+        env:
+          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,3 @@ jobs:
         env:
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      - run: pnpm --filter cms test:int
-        env:
-          PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/notification.yml
+++ b/.github/workflows/notification.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pull_request_created:
-    if: github.event_name == 'pull_request' && github.event.action == 'opened' || github.event.action == 'reopened'
+    if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     runs-on: ubuntu-latest
     steps:
       - name: Discord Webhook Action

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .vscode/
 node_modules/
+
+# Only pnpm-lock.yaml at the root is committed; other lockfiles are mistakes.
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ cd ssa
 
 ### 2. Install dependencies
 
-Install dependencies for each package separately:
+This repo is a pnpm workspace — run a single install at the root and pnpm will handle both packages:
 
 ```bash
-cd web && pnpm install
-cd ../cms && pnpm install
+pnpm install
 ```
+
+> Use pnpm only. `npm install` and `yarn install` are not supported and will produce a broken `node_modules/`.
 
 ### 3. Configure environment variables
 


### PR DESCRIPTION
## Summary

- **CI: fix boolean precedence in the notification workflow.** `notification.yml` had `A && B || C` where `A && (B || C)` was intended. In practice the top-level `on: pull_request` trigger saved us, so this isn't user-visible — but the logic was wrong.
- **gitignore: block npm/yarn lockfiles repo-wide.** This repo is a pnpm workspace (`pnpm-workspace.yaml` + root `pnpm-lock.yaml`). A recent feature branch accidentally committed a `web/package-lock.json` from a stray `npm install`. The gitignore now ignores `package-lock.json` and `yarn.lock` anywhere in the tree, so it can't happen by accident again.
- **README: recommend `pnpm install` at the root** instead of `cd web && pnpm install && cd ../cms && pnpm install`. In a pnpm workspace, one root install handles both packages — shorter, harder to typo into `npm install`, and matches how pnpm workspaces are designed to be used. Added a one-line note that npm/yarn aren't supported.

## What got dropped from this PR

Initially also added a `pnpm --filter cms test:int` step to the CMS job. CI surfaced that the integration test can't actually run on GitHub-hosted runners: `getPayload()` opens a Postgres connection and `DATABASE_URL` resolves to an IPv6-only host, which GH runners can't reach (`ENETUNREACH`). The CMS build step never noticed because `next build` doesn't actually open a DB connection at build time. Reverting that step here — proper fix is wiring up a Postgres service container in CI, which belongs in its own PR.

## Test plan

- [ ] CI runs and passes on this PR.
- [ ] Open / reopen / close a PR after merge and confirm the Discord notification still fires correctly.
- [ ] After merge, `git ls-files '**/package-lock.json'` returns nothing (sanity check that no stray lockfiles slipped in).
- [ ] Run `pnpm install` at the repo root on a fresh clone and confirm both `web/` and `cms/` install cleanly.

## Notes

- This does **not** clean up the existing `web/package-lock.json` on feature branches that already committed it — those branches still need a `git rm web/package-lock.json` from their authors (flagged on #75).
- Did not add an `only-allow pnpm` preinstall guard. Discussed offline — for our team size, the `.gitignore` rule is enough and the tech lead can catch the rare `npm install` mistake during review or direct support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)