### PR TITLE
feature: implement google authentication for sign up

### DIFF
--- a/cms/.env.example
+++ b/cms/.env.example
@@ -8,3 +8,6 @@ STRIPE_PRICE_ID=price...
 
 # URL of the public web app (used for Stripe success/cancel redirects)
 WEB_URL=http://localhost:3000
+
+# Secret used to temporarily encrypt signup passwords until Stripe confirms payment
+SIGNUP_ENCRYPTION_KEY=YOUR_SIGNUP_ENCRYPTION_KEY_HERE

--- a/cms/src/app/signup/check-email/route.ts
+++ b/cms/src/app/signup/check-email/route.ts
@@ -1,0 +1,56 @@
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+export async function POST(request: Request) {
+  let body: { email?: string }
+
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const email = normalizeEmail(body.email ?? '')
+
+  if (!isValidEmail(email)) {
+    return Response.json({ error: 'Valid email is required' }, { status: 400 })
+  }
+
+  const payload = await getPayload({ config: configPromise })
+
+  const [existingUser, existingRegisteredMember] = await Promise.all([
+    payload.find({
+      collection: 'users',
+      limit: 1,
+      overrideAccess: true,
+      pagination: false,
+      where: { email: { equals: email } },
+    }),
+    payload.find({
+      collection: 'members',
+      limit: 1,
+      overrideAccess: true,
+      pagination: false,
+      where: {
+        and: [{ email: { equals: email } }, { status: { not_equals: 'pending' } }],
+      },
+    }),
+  ])
+
+  if (existingUser.docs.length > 0 || existingRegisteredMember.docs.length > 0) {
+    return Response.json(
+      { available: false, error: 'An account with this email already exists' },
+      { status: 409 },
+    )
+  }
+
+  return Response.json({ available: true })
+}

--- a/cms/src/app/stripe/_lib/activatePaidSignup.ts
+++ b/cms/src/app/stripe/_lib/activatePaidSignup.ts
@@ -1,0 +1,118 @@
+import type { Payload } from 'payload'
+
+import { decryptSignupPassword } from './signupPassword'
+
+type ActivatePaidSignupArgs = {
+  memberId: number
+  payload: Payload
+  stripeCustomerId?: null | string
+}
+
+type MemberWithSignupPassword = {
+  areaOfStudy?: null | string
+  authProvider?: 'email' | 'google' | null
+  email: string
+  encryptedSignupPassword?: null | string
+  ethnicity?: 'chinese' | 'eurasian' | 'indian' | 'malay' | 'other' | null
+  firstName?: null | string
+  gender?: 'female' | 'male' | 'non-binary' | 'prefer-not-to-say' | null
+  googleSub?: null | string
+  id: number
+  lastName?: null | string
+  membershipExpiryDate?: null | string
+  name: string
+  phone: string
+  returningMember?: boolean | null
+  studentId?: null | string
+  upi?: null | string
+  yearOfUniversity?: '1' | '2' | '3' | '4' | '5+' | 'postgrad' | null
+}
+
+function splitName(name: string) {
+  const [firstName, ...rest] = name.trim().split(/\s+/)
+
+  return {
+    firstName: firstName || undefined,
+    lastName: rest.join(' ') || undefined,
+  }
+}
+
+export async function activatePaidSignup({
+  memberId,
+  payload,
+  stripeCustomerId,
+}: ActivatePaidSignupArgs) {
+  const member = (await payload.findByID({
+    collection: 'members',
+    id: memberId,
+    overrideAccess: true,
+    showHiddenFields: true,
+  })) as MemberWithSignupPassword
+
+  const existingUser = await payload.find({
+    collection: 'users',
+    limit: 1,
+    overrideAccess: true,
+    pagination: false,
+    where: {
+      email: {
+        equals: member.email,
+      },
+    },
+  })
+
+  const fallbackName = splitName(member.name)
+  const userData = {
+    name: member.name,
+    authProvider: member.authProvider || 'email',
+    googleSub: member.googleSub,
+    firstName: member.firstName || fallbackName.firstName,
+    lastName: member.lastName || fallbackName.lastName,
+    phone: member.phone,
+    membershipStatus: 'active' as const,
+    membershipExpiryDate: member.membershipExpiryDate,
+    stripeCustomerId,
+    upi: member.upi,
+    studentId: member.studentId,
+    areaOfStudy: member.areaOfStudy,
+    yearOfUniversity: member.yearOfUniversity,
+    gender: member.gender,
+    ethnicity: member.ethnicity,
+    returningMember: member.returningMember ?? false,
+  }
+
+  if (existingUser.docs.length === 0) {
+    if (!member.encryptedSignupPassword) {
+      throw new Error('Paid member is missing encrypted signup password')
+    }
+
+    await payload.create({
+      collection: 'users',
+      overrideAccess: true,
+      data: {
+        email: member.email,
+        password: decryptSignupPassword(member.encryptedSignupPassword),
+        role: 'member',
+        ...userData,
+      },
+    })
+  } else {
+    await payload.update({
+      collection: 'users',
+      id: existingUser.docs[0].id,
+      overrideAccess: true,
+      data: userData,
+    })
+  }
+
+  await payload.update({
+    collection: 'members',
+    id: memberId,
+    overrideAccess: true,
+    data: {
+      status: 'active',
+      encryptedSignupPassword: null,
+      ...(stripeCustomerId ? { stripeCustomerId } : {}),
+    },
+  })
+}

--- a/cms/src/app/stripe/_lib/signupPassword.ts
+++ b/cms/src/app/stripe/_lib/signupPassword.ts
@@ -1,0 +1,48 @@
+import crypto from 'crypto'
+
+const algorithm = 'aes-256-gcm'
+const version = 'v1'
+
+function getEncryptionKey() {
+  const secret = process.env.SIGNUP_ENCRYPTION_KEY || process.env.PAYLOAD_SECRET
+
+  if (!secret) {
+    throw new Error('SIGNUP_ENCRYPTION_KEY or PAYLOAD_SECRET must be configured')
+  }
+
+  return crypto.createHash('sha256').update(secret).digest()
+}
+
+export function encryptSignupPassword(password: string) {
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv(algorithm, getEncryptionKey(), iv)
+  const encrypted = Buffer.concat([cipher.update(password, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+
+  return [
+    version,
+    iv.toString('base64url'),
+    authTag.toString('base64url'),
+    encrypted.toString('base64url'),
+  ].join(':')
+}
+
+export function decryptSignupPassword(value: string) {
+  const [storedVersion, iv, authTag, encrypted] = value.split(':')
+
+  if (storedVersion !== version || !iv || !authTag || !encrypted) {
+    throw new Error('Invalid encrypted signup password')
+  }
+
+  const decipher = crypto.createDecipheriv(
+    algorithm,
+    getEncryptionKey(),
+    Buffer.from(iv, 'base64url'),
+  )
+  decipher.setAuthTag(Buffer.from(authTag, 'base64url'))
+
+  return Buffer.concat([
+    decipher.update(Buffer.from(encrypted, 'base64url')),
+    decipher.final(),
+  ]).toString('utf8')
+}

--- a/cms/src/app/stripe/checkout/confirm/route.ts
+++ b/cms/src/app/stripe/checkout/confirm/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from 'next/server'
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+import Stripe from 'stripe'
+import { activatePaidSignup } from '../../_lib/activatePaidSignup'
+
+export const GET = async (request: NextRequest) => {
+  const sessionId = request.nextUrl.searchParams.get('session_id')
+
+  if (!sessionId) {
+    return Response.json({ error: 'Missing session_id' }, { status: 400 })
+  }
+
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY
+
+  if (!stripeSecretKey) {
+    return Response.json({ error: 'Stripe not configured' }, { status: 500 })
+  }
+
+  const stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-04-22.dahlia' })
+
+  let session: Stripe.Checkout.Session
+  try {
+    session = await stripe.checkout.sessions.retrieve(sessionId)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to retrieve Stripe session'
+    return Response.json({ error: message }, { status: 502 })
+  }
+
+  const memberId = Number(session.metadata?.memberId)
+  const stripeCustomerId =
+    typeof session.customer === 'string' ? session.customer : (session.customer?.id ?? null)
+
+  if (session.payment_status !== 'paid') {
+    return Response.json({
+      confirmed: false,
+      paymentStatus: session.payment_status,
+    })
+  }
+
+  if (!Number.isFinite(memberId)) {
+    return Response.json({ error: 'Stripe session is missing member metadata' }, { status: 422 })
+  }
+
+  const payload = await getPayload({ config: configPromise })
+
+  try {
+    await activatePaidSignup({
+      memberId,
+      payload,
+      stripeCustomerId,
+    })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to activate paid signup'
+    return Response.json({ error: message }, { status: 500 })
+  }
+
+  return Response.json({
+    confirmed: true,
+    paymentStatus: session.payment_status,
+  })
+}

--- a/cms/src/app/stripe/checkout/route.ts
+++ b/cms/src/app/stripe/checkout/route.ts
@@ -1,12 +1,43 @@
 import { NextRequest } from 'next/server'
 import configPromise from '@payload-config'
+import crypto from 'crypto'
 import { getPayload } from 'payload'
 import Stripe from 'stripe'
+import { encryptSignupPassword } from '../_lib/signupPassword'
+
+function getWebUrl(request: NextRequest) {
+  const forwardedWebUrl = request.headers.get('x-web-url')
+  const configuredWebUrl = process.env.WEB_URL
+  const fallbackWebUrl = 'http://localhost:3000'
+
+  for (const value of [forwardedWebUrl, configuredWebUrl, fallbackWebUrl]) {
+    if (!value) continue
+
+    try {
+      const url = new URL(value)
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        return url.origin
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return fallbackWebUrl
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase()
+}
 
 export const POST = async (request: NextRequest) => {
   let body: {
+    firstName?: string
+    lastName?: string
     name?: string
+    authProvider?: 'email' | 'google'
     email?: string
+    googleSub?: string
     password?: string
     phone?: string
     upi?: string
@@ -24,8 +55,12 @@ export const POST = async (request: NextRequest) => {
   }
 
   const {
+    firstName,
+    lastName,
     name,
+    authProvider: requestedAuthProvider,
     email,
+    googleSub,
     password,
     phone,
     upi,
@@ -36,10 +71,14 @@ export const POST = async (request: NextRequest) => {
     ethnicity,
     returningMember,
   } = body
+  const authProvider = requestedAuthProvider === 'google' ? 'google' : 'email'
+  const normalizedEmail = email ? normalizeEmail(email) : ''
+
   if (
     !name ||
-    !email ||
-    !password ||
+    !normalizedEmail ||
+    (authProvider === 'email' && !password) ||
+    (authProvider === 'google' && !googleSub) ||
     !phone ||
     !upi ||
     !studentId ||
@@ -52,7 +91,7 @@ export const POST = async (request: NextRequest) => {
     return Response.json(
       {
         error:
-          'Missing required fields: name, email, password, phone, upi, studentId, areaOfStudy, yearOfUniversity, gender, ethnicity, returningMember',
+          'Missing required fields: name, email, phone, upi, studentId, areaOfStudy, yearOfUniversity, gender, ethnicity, returningMember',
       },
       { status: 400 },
     )
@@ -60,7 +99,7 @@ export const POST = async (request: NextRequest) => {
 
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY
   const priceId = process.env.STRIPE_PRICE_ID
-  const webUrl = process.env.WEB_URL || 'http://localhost:3000'
+  const webUrl = getWebUrl(request)
 
   if (!stripeSecretKey || !priceId) {
     return Response.json({ error: 'Stripe not configured' }, { status: 500 })
@@ -68,6 +107,11 @@ export const POST = async (request: NextRequest) => {
 
   const payload = await getPayload({ config: configPromise })
   const stripe = new Stripe(stripeSecretKey, { apiVersion: '2026-04-22.dahlia' })
+  const memberPassword =
+    authProvider === 'google' ? crypto.randomBytes(32).toString('base64url') : (password ?? '')
+  const encryptedSignupPassword = encryptSignupPassword(memberPassword)
+  const trimmedFirstName = firstName?.trim()
+  const trimmedLastName = lastName?.trim()
 
   // Reuse an existing pending member so a transient Stripe failure doesn't
   // permanently block the email from retrying.
@@ -75,9 +119,35 @@ export const POST = async (request: NextRequest) => {
   let memberCreatedHere = false
   let existingStripeCustomerId: string | null | undefined
 
+  const [existingUser, existingRegisteredMember] = await Promise.all([
+    payload.find({
+      collection: 'users',
+      limit: 1,
+      overrideAccess: true,
+      pagination: false,
+      where: { email: { equals: normalizedEmail } },
+    }),
+    payload.find({
+      collection: 'members',
+      limit: 1,
+      overrideAccess: true,
+      pagination: false,
+      where: {
+        and: [{ email: { equals: normalizedEmail } }, { status: { not_equals: 'pending' } }],
+      },
+    }),
+  ])
+
+  if (existingUser.docs.length > 0 || existingRegisteredMember.docs.length > 0) {
+    return Response.json({ error: 'An account with this email already exists' }, { status: 409 })
+  }
+
   const existing = await payload.find({
     collection: 'members',
-    where: { and: [{ email: { equals: email } }, { status: { equals: 'pending' } }] },
+    overrideAccess: true,
+    where: {
+      and: [{ email: { equals: normalizedEmail } }, { status: { equals: 'pending' } }],
+    },
     limit: 1,
   })
 
@@ -93,8 +163,13 @@ export const POST = async (request: NextRequest) => {
       overrideAccess: true,
       data: {
         name,
+        firstName: trimmedFirstName,
+        lastName: trimmedLastName,
+        authProvider,
         phone,
-        password,
+        googleSub: authProvider === 'google' ? googleSub : null,
+        password: memberPassword,
+        encryptedSignupPassword,
         upi,
         studentId,
         areaOfStudy,
@@ -114,8 +189,13 @@ export const POST = async (request: NextRequest) => {
         overrideAccess: true,
         data: {
           name,
-          email,
-          password,
+          firstName: trimmedFirstName,
+          lastName: trimmedLastName,
+          authProvider,
+          email: normalizedEmail,
+          googleSub: authProvider === 'google' ? googleSub : undefined,
+          password: memberPassword,
+          encryptedSignupPassword,
           phone,
           upi,
           studentId,
@@ -132,7 +212,10 @@ export const POST = async (request: NextRequest) => {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to create member'
       if (message.toLowerCase().includes('duplicate') || message.toLowerCase().includes('unique')) {
-        return Response.json({ error: 'An account with this email already exists' }, { status: 409 })
+        return Response.json(
+          { error: 'An account with this email already exists' },
+          { status: 409 },
+        )
       }
       return Response.json({ error: message }, { status: 400 })
     }
@@ -146,7 +229,7 @@ export const POST = async (request: NextRequest) => {
     customerId = existingStripeCustomerId
   } else {
     try {
-      const customer = await stripe.customers.create({ email, name })
+      const customer = await stripe.customers.create({ email: normalizedEmail, name })
       customerId = customer.id
       customerCreatedHere = true
       // Persist the customer ID so future retries can reuse it.
@@ -160,7 +243,9 @@ export const POST = async (request: NextRequest) => {
         .catch(() => {})
     } catch (err: unknown) {
       if (memberCreatedHere) {
-        await payload.delete({ collection: 'members', id: memberId }).catch(() => {})
+        await payload
+          .delete({ collection: 'members', id: memberId, overrideAccess: true })
+          .catch(() => {})
       }
       const message = err instanceof Error ? err.message : 'Failed to create Stripe customer'
       return Response.json({ error: message }, { status: 502 })
@@ -178,11 +263,23 @@ export const POST = async (request: NextRequest) => {
     })
 
     if (!session.url) {
-      if (memberCreatedHere) {
-        await payload.delete({ collection: 'members', id: memberId }).catch(() => {})
-        if (customerCreatedHere) {
-          await stripe.customers.del(customerId).catch(() => {})
+      if (customerCreatedHere) {
+        await stripe.customers.del(customerId).catch(() => {})
+        if (!memberCreatedHere) {
+          await payload
+            .update({
+              collection: 'members',
+              id: memberId,
+              overrideAccess: true,
+              data: { stripeCustomerId: null },
+            })
+            .catch(() => {})
         }
+      }
+      if (memberCreatedHere) {
+        await payload
+          .delete({ collection: 'members', id: memberId, overrideAccess: true })
+          .catch(() => {})
       }
       return Response.json(
         { error: 'Stripe did not provide a checkout URL for the created session' },
@@ -192,11 +289,23 @@ export const POST = async (request: NextRequest) => {
 
     return Response.json({ checkoutUrl: session.url })
   } catch (err: unknown) {
-    if (memberCreatedHere) {
-      await payload.delete({ collection: 'members', id: memberId }).catch(() => {})
-      if (customerCreatedHere) {
-        await stripe.customers.del(customerId).catch(() => {})
+    if (customerCreatedHere) {
+      await stripe.customers.del(customerId).catch(() => {})
+      if (!memberCreatedHere) {
+        await payload
+          .update({
+            collection: 'members',
+            id: memberId,
+            overrideAccess: true,
+            data: { stripeCustomerId: null },
+          })
+          .catch(() => {})
       }
+    }
+    if (memberCreatedHere) {
+      await payload
+        .delete({ collection: 'members', id: memberId, overrideAccess: true })
+        .catch(() => {})
     }
     const message = err instanceof Error ? err.message : 'Failed to create Stripe checkout session'
     return Response.json({ error: message }, { status: 502 })

--- a/cms/src/app/stripe/webhook/route.ts
+++ b/cms/src/app/stripe/webhook/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
 import Stripe from 'stripe'
+import { activatePaidSignup } from '../_lib/activatePaidSignup'
 
 export const POST = async (request: NextRequest) => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY
@@ -38,7 +39,7 @@ export const POST = async (request: NextRequest) => {
 
     const { memberId: rawMemberId } = session.metadata ?? {}
     const stripeCustomerId =
-      typeof session.customer === 'string' ? session.customer : session.customer?.id ?? null
+      typeof session.customer === 'string' ? session.customer : (session.customer?.id ?? null)
 
     const memberId = Number(rawMemberId)
     if (!Number.isFinite(memberId)) {
@@ -52,17 +53,14 @@ export const POST = async (request: NextRequest) => {
     const payload = await getPayload({ config: configPromise })
 
     try {
-      await payload.update({
-        collection: 'members',
-        id: memberId,
-        data: {
-          status: 'active',
-          ...(stripeCustomerId ? { stripeCustomerId } : {}),
-        },
+      await activatePaidSignup({
+        memberId,
+        payload,
+        stripeCustomerId,
       })
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to update member'
-      console.error('Stripe webhook: failed to update member', { memberId, error: message })
+      const message = err instanceof Error ? err.message : 'Failed to activate paid signup'
+      console.error('Stripe webhook: failed to activate paid signup', { memberId, error: message })
       // Return 500 so Stripe retries with exponential backoff
       return Response.json({ error: message }, { status: 500 })
     }

--- a/cms/src/collections/Members.ts
+++ b/cms/src/collections/Members.ts
@@ -16,9 +16,34 @@ export const Members: CollectionConfig = {
       required: true,
     },
     {
+      name: 'firstName',
+      type: 'text',
+    },
+    {
+      name: 'lastName',
+      type: 'text',
+    },
+    {
       name: 'phone',
       type: 'text',
       required: true,
+    },
+    {
+      name: 'authProvider',
+      type: 'select',
+      defaultValue: 'email',
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'Google', value: 'google' },
+      ],
+      required: true,
+    },
+    {
+      name: 'googleSub',
+      type: 'text',
+      admin: {
+        description: 'Google account subject identifier for OAuth signups.',
+      },
     },
     {
       name: 'status',
@@ -26,15 +51,15 @@ export const Members: CollectionConfig = {
       options: [
         {
           label: 'ACTIVE',
-          value: 'active'
+          value: 'active',
         },
         {
           label: 'EXPIRED',
-          value: 'expired'
+          value: 'expired',
         },
         {
           label: 'PENDING',
-          value: 'pending'
+          value: 'pending',
         },
       ],
       required: true,
@@ -47,6 +72,11 @@ export const Members: CollectionConfig = {
     {
       name: 'stripeCustomerId',
       type: 'text',
+    },
+    {
+      name: 'encryptedSignupPassword',
+      type: 'text',
+      hidden: true,
     },
     {
       name: 'emergencyContactName',
@@ -106,5 +136,5 @@ export const Members: CollectionConfig = {
       type: 'checkbox',
       defaultValue: false,
     },
-  ]
+  ],
 }

--- a/cms/src/collections/Users.ts
+++ b/cms/src/collections/Users.ts
@@ -5,9 +5,125 @@ export const Users: CollectionConfig = {
   admin: {
     useAsTitle: 'email',
   },
+  access: {
+    admin: ({ req }) => {
+      if (req.user?.collection !== 'users') return false
+
+      return (req.user as { role?: string | null }).role !== 'member'
+    },
+  },
   auth: true,
   fields: [
     // Email added by default
-    // Add more fields as needed
+    {
+      name: 'role',
+      type: 'select',
+      defaultValue: 'admin',
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Member', value: 'member' },
+      ],
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'text',
+    },
+    {
+      name: 'authProvider',
+      type: 'select',
+      defaultValue: 'email',
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'Google', value: 'google' },
+      ],
+    },
+    {
+      name: 'googleSub',
+      type: 'text',
+      admin: {
+        description: 'Google account subject identifier for OAuth signups.',
+      },
+    },
+    {
+      name: 'firstName',
+      type: 'text',
+    },
+    {
+      name: 'lastName',
+      type: 'text',
+    },
+    {
+      name: 'phone',
+      type: 'text',
+    },
+    {
+      name: 'membershipStatus',
+      type: 'select',
+      defaultValue: 'active',
+      options: [
+        { label: 'Active', value: 'active' },
+        { label: 'Expired', value: 'expired' },
+        { label: 'Pending', value: 'pending' },
+      ],
+    },
+    {
+      name: 'membershipExpiryDate',
+      type: 'date',
+    },
+    {
+      name: 'stripeCustomerId',
+      type: 'text',
+    },
+    {
+      name: 'upi',
+      type: 'text',
+    },
+    {
+      name: 'studentId',
+      type: 'text',
+    },
+    {
+      name: 'areaOfStudy',
+      type: 'text',
+    },
+    {
+      name: 'yearOfUniversity',
+      type: 'select',
+      options: [
+        { label: 'Year 1', value: '1' },
+        { label: 'Year 2', value: '2' },
+        { label: 'Year 3', value: '3' },
+        { label: 'Year 4', value: '4' },
+        { label: 'Year 5+', value: '5+' },
+        { label: 'Postgraduate', value: 'postgrad' },
+      ],
+    },
+    {
+      name: 'gender',
+      type: 'select',
+      options: [
+        { label: 'Male', value: 'male' },
+        { label: 'Female', value: 'female' },
+        { label: 'Non-binary', value: 'non-binary' },
+        { label: 'Prefer not to say', value: 'prefer-not-to-say' },
+      ],
+    },
+    {
+      name: 'ethnicity',
+      type: 'select',
+      options: [
+        { label: 'Chinese', value: 'chinese' },
+        { label: 'Malay', value: 'malay' },
+        { label: 'Indian', value: 'indian' },
+        { label: 'Eurasian', value: 'eurasian' },
+        { label: 'Other', value: 'other' },
+      ],
+    },
+    {
+      name: 'returningMember',
+      type: 'checkbox',
+      defaultValue: false,
+    },
   ],
 }

--- a/cms/src/payload-types.ts
+++ b/cms/src/payload-types.ts
@@ -152,6 +152,26 @@ export interface MemberAuthOperations {
  */
 export interface User {
   id: number
+  role: 'admin' | 'member'
+  name?: string | null
+  authProvider?: ('email' | 'google') | null
+  /**
+   * Google account subject identifier for OAuth signups.
+   */
+  googleSub?: string | null
+  firstName?: string | null
+  lastName?: string | null
+  phone?: string | null
+  membershipStatus?: ('active' | 'expired' | 'pending') | null
+  membershipExpiryDate?: string | null
+  stripeCustomerId?: string | null
+  upi?: string | null
+  studentId?: string | null
+  areaOfStudy?: string | null
+  yearOfUniversity?: ('1' | '2' | '3' | '4' | '5+' | 'postgrad') | null
+  gender?: ('male' | 'female' | 'non-binary' | 'prefer-not-to-say') | null
+  ethnicity?: ('chinese' | 'malay' | 'indian' | 'eurasian' | 'other') | null
+  returningMember?: boolean | null
   updatedAt: string
   createdAt: string
   email: string
@@ -247,10 +267,18 @@ export interface Exec {
 export interface Member {
   id: number
   name: string
+  firstName?: string | null
+  lastName?: string | null
   phone: string
+  authProvider: 'email' | 'google'
+  /**
+   * Google account subject identifier for OAuth signups.
+   */
+  googleSub?: string | null
   status: 'active' | 'expired' | 'pending'
   membershipExpiryDate?: string | null
   stripeCustomerId?: string | null
+  encryptedSignupPassword?: string | null
   emergencyContactName?: string | null
   emergencyContactPhone?: string | null
   upi?: string | null
@@ -384,6 +412,23 @@ export interface PayloadMigration {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  role?: T
+  name?: T
+  authProvider?: T
+  googleSub?: T
+  firstName?: T
+  lastName?: T
+  phone?: T
+  membershipStatus?: T
+  membershipExpiryDate?: T
+  stripeCustomerId?: T
+  upi?: T
+  studentId?: T
+  areaOfStudy?: T
+  yearOfUniversity?: T
+  gender?: T
+  ethnicity?: T
+  returningMember?: T
   updatedAt?: T
   createdAt?: T
   email?: T
@@ -472,10 +517,15 @@ export interface ExecsSelect<T extends boolean = true> {
  */
 export interface MembersSelect<T extends boolean = true> {
   name?: T
+  firstName?: T
+  lastName?: T
   phone?: T
+  authProvider?: T
+  googleSub?: T
   status?: T
   membershipExpiryDate?: T
   stripeCustomerId?: T
+  encryptedSignupPassword?: T
   emergencyContactName?: T
   emergencyContactPhone?: T
   upi?: T

--- a/cms/tests/helpers/seedUser.ts
+++ b/cms/tests/helpers/seedUser.ts
@@ -4,7 +4,8 @@ import config from '../../src/payload.config.js'
 export const testUser = {
   email: 'dev@payloadcms.com',
   password: 'test',
-}
+  role: 'admin',
+} as const
 
 /**
  * Seeds a test user for e2e admin tests.

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,20 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+Create a `.env.local` file with the app URLs and OAuth keys used by the signup flow:
+
+```bash
+CMS_URL=http://localhost:3001
+NEXT_PUBLIC_CMS_URL=http://localhost:3001
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_OAUTH_COOKIE_SECRET=use-a-long-random-secret
+# Optional when the derived localhost callback is not correct:
+# GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
+```
+
+The Google OAuth client must allow the redirect URI shown above for local development.
+
 First, run the development server:
 
 ```bash

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -654,6 +654,126 @@
     "node_modules/typescript": {
       "resolved": "../node_modules/.pnpm/typescript@5.7.3/node_modules/typescript",
       "link": true
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/web/src/app/api/auth/google/callback/route.ts
+++ b/web/src/app/api/auth/google/callback/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import {
+  createGoogleSignupSession,
+  googleOAuthStateCookie,
+  googleSignupSessionCookie,
+} from '@/lib/googleSignupSession'
+
+type GoogleTokenResponse = {
+  access_token?: string
+  error?: string
+  error_description?: string
+  expires_in?: number
+  id_token?: string
+  scope?: string
+  token_type?: string
+}
+
+type GoogleTokenInfoResponse = {
+  aud?: string
+  email?: string
+  email_verified?: boolean | string
+  family_name?: string
+  given_name?: string
+  name?: string
+  sub?: string
+}
+
+function getRedirectUri(request: NextRequest) {
+  const configuredRedirectUri = process.env.GOOGLE_OAUTH_REDIRECT_URI
+  if (configuredRedirectUri) return configuredRedirectUri
+
+  return `${request.nextUrl.origin}/api/auth/google/callback`
+}
+
+function redirectToSignup(
+  request: NextRequest,
+  params: Record<string, string>,
+) {
+  const url = new URL('/signup', request.nextUrl.origin)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value)
+  }
+
+  return NextResponse.redirect(url)
+}
+
+export async function GET(request: NextRequest) {
+  const clientId = process.env.GOOGLE_CLIENT_ID
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET
+
+  if (!clientId || !clientSecret) {
+    return Response.json(
+      { error: 'Google OAuth is not configured' },
+      { status: 500 },
+    )
+  }
+
+  const code = request.nextUrl.searchParams.get('code')
+  const state = request.nextUrl.searchParams.get('state')
+  const storedState = request.cookies.get(googleOAuthStateCookie)?.value
+
+  if (!code || !state || !storedState || state !== storedState) {
+    const response = redirectToSignup(request, { google: 'invalid_state' })
+    response.cookies.delete(googleOAuthStateCookie)
+    return response
+  }
+
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: getRedirectUri(request),
+    }),
+  })
+  const tokenData = (await tokenResponse.json()) as GoogleTokenResponse
+
+  if (!tokenResponse.ok || !tokenData.id_token) {
+    console.error(
+      '[google-oauth] token exchange failed',
+      tokenData.error,
+      tokenData.error_description,
+    )
+    const response = redirectToSignup(request, { google: 'token_failed' })
+    response.cookies.delete(googleOAuthStateCookie)
+    return response
+  }
+
+  const tokenInfoResponse = await fetch(
+    `https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(tokenData.id_token)}`,
+  )
+  const tokenInfo = (await tokenInfoResponse.json()) as GoogleTokenInfoResponse
+
+  if (
+    !tokenInfoResponse.ok ||
+    tokenInfo.aud !== clientId ||
+    !tokenInfo.sub ||
+    !tokenInfo.email ||
+    tokenInfo.email_verified === false ||
+    tokenInfo.email_verified === 'false'
+  ) {
+    console.error('[google-oauth] invalid id token')
+    const response = redirectToSignup(request, { google: 'invalid_token' })
+    response.cookies.delete(googleOAuthStateCookie)
+    return response
+  }
+
+  const response = redirectToSignup(request, { google: 'connected' })
+  response.cookies.delete(googleOAuthStateCookie)
+  response.cookies.set(
+    googleSignupSessionCookie,
+    createGoogleSignupSession({
+      email: tokenInfo.email,
+      firstName: tokenInfo.given_name,
+      googleSub: tokenInfo.sub,
+      lastName: tokenInfo.family_name,
+      name: tokenInfo.name,
+    }),
+    {
+      httpOnly: true,
+      maxAge: 30 * 60,
+      path: '/',
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    },
+  )
+
+  return response
+}

--- a/web/src/app/api/auth/google/route.ts
+++ b/web/src/app/api/auth/google/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import {
+  createOAuthState,
+  googleOAuthStateCookie,
+} from '@/lib/googleSignupSession'
+
+function getRedirectUri(request: NextRequest) {
+  const configuredRedirectUri = process.env.GOOGLE_OAUTH_REDIRECT_URI
+  if (configuredRedirectUri) return configuredRedirectUri
+
+  return `${request.nextUrl.origin}/api/auth/google/callback`
+}
+
+export function GET(request: NextRequest) {
+  const clientId = process.env.GOOGLE_CLIENT_ID
+
+  if (!clientId) {
+    return Response.json(
+      { error: 'GOOGLE_CLIENT_ID not configured' },
+      { status: 500 },
+    )
+  }
+
+  const state = createOAuthState()
+  const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+  authUrl.searchParams.set('client_id', clientId)
+  authUrl.searchParams.set('redirect_uri', getRedirectUri(request))
+  authUrl.searchParams.set('response_type', 'code')
+  authUrl.searchParams.set('scope', 'openid email profile')
+  authUrl.searchParams.set('state', state)
+  authUrl.searchParams.set('prompt', 'select_account')
+
+  const response = NextResponse.redirect(authUrl)
+  response.cookies.set(googleOAuthStateCookie, state, {
+    httpOnly: true,
+    maxAge: 10 * 60,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  return response
+}

--- a/web/src/app/api/auth/google/session/route.ts
+++ b/web/src/app/api/auth/google/session/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import {
+  googleSignupSessionCookie,
+  readGoogleSignupSession,
+} from '@/lib/googleSignupSession'
+
+export function GET(request: NextRequest) {
+  const profile = readGoogleSignupSession(
+    request.cookies.get(googleSignupSessionCookie)?.value,
+  )
+
+  if (!profile) {
+    return Response.json({ error: 'No Google signup session' }, { status: 404 })
+  }
+
+  return Response.json({ profile })
+}
+
+export function DELETE() {
+  const response = NextResponse.json({ ok: true })
+  response.cookies.set(googleSignupSessionCookie, '', {
+    httpOnly: true,
+    maxAge: 0,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  return response
+}

--- a/web/src/app/api/checkout/route.ts
+++ b/web/src/app/api/checkout/route.ts
@@ -1,11 +1,28 @@
 import { NextRequest } from 'next/server'
 
+import {
+  googleSignupSessionCookie,
+  readGoogleSignupSession,
+} from '@/lib/googleSignupSession'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function textValue(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}
+
 export const POST = async (request: NextRequest) => {
   const cmsUrl = process.env.CMS_URL
 
   if (!cmsUrl) {
     return Response.json({ error: 'CMS_URL not configured' }, { status: 500 })
   }
+
+  const webUrl =
+    request.headers.get('origin') ??
+    `${request.headers.get('x-forwarded-proto') ?? 'http'}://${request.headers.get('host')}`
 
   let body: unknown
   try {
@@ -14,11 +31,52 @@ export const POST = async (request: NextRequest) => {
     return Response.json({ error: 'Invalid request body' }, { status: 400 })
   }
 
+  if (!isRecord(body)) {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  if (body.authProvider === 'google') {
+    const profile = readGoogleSignupSession(
+      request.cookies.get(googleSignupSessionCookie)?.value,
+    )
+
+    if (!profile) {
+      return Response.json(
+        {
+          error: 'Google sign up session expired. Please connect Google again.',
+        },
+        { status: 401 },
+      )
+    }
+
+    const firstName =
+      textValue(body.firstName)?.trim() || profile.firstName || ''
+    const lastName = textValue(body.lastName)?.trim() || profile.lastName || ''
+
+    body = {
+      ...body,
+      authProvider: 'google',
+      email: profile.email,
+      firstName,
+      googleSub: profile.googleSub,
+      lastName,
+      name: `${firstName} ${lastName}`.trim() || profile.name || profile.email,
+    }
+  } else {
+    body = {
+      ...body,
+      authProvider: 'email',
+    }
+  }
+
   let cmsResponse: Response
   try {
     cmsResponse = await fetch(`${cmsUrl}/stripe/checkout`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Web-Url': webUrl,
+      },
       body: JSON.stringify(body),
     })
   } catch (err: unknown) {

--- a/web/src/app/api/signup/check-email/route.ts
+++ b/web/src/app/api/signup/check-email/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const cmsUrl = process.env.CMS_URL
+
+  if (!cmsUrl) {
+    return Response.json({ error: 'CMS_URL not configured' }, { status: 500 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  let cmsResponse: Response
+  try {
+    cmsResponse = await fetch(`${cmsUrl}/signup/check-email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Failed to reach CMS'
+    return Response.json({ error: message }, { status: 502 })
+  }
+
+  const cmsBody = await cmsResponse.text()
+  let data: unknown
+
+  if (!cmsBody) {
+    data = { error: 'Empty CMS response' }
+  } else {
+    try {
+      data = JSON.parse(cmsBody)
+    } catch {
+      console.error(
+        '[api/signup/check-email] CMS returned non-JSON body:',
+        cmsBody,
+      )
+      data = { error: 'Email availability service error. Please try again.' }
+    }
+  }
+
+  return Response.json(data, { status: cmsResponse.status })
+}

--- a/web/src/app/signup/_components/AccountSignUpStep.tsx
+++ b/web/src/app/signup/_components/AccountSignUpStep.tsx
@@ -1,0 +1,100 @@
+import type { FormData } from './types'
+import CardSection from '@/components/CardSection'
+import InputField from '@/components/InputField'
+import { FcGoogle } from 'react-icons/fc'
+
+export default function AccountSignUpStep({
+  data,
+  onChange,
+  fieldErrors,
+  onGoogleAuth,
+  onUseEmailAuth,
+}: {
+  data: FormData
+  onChange: (field: keyof FormData, value: string) => void
+  fieldErrors: Record<string, string>
+  onGoogleAuth: () => void
+  onUseEmailAuth: () => void
+}) {
+  const isGoogleSignup = data.authProvider === 'google'
+
+  return (
+    <CardSection title="Account Sign Up">
+      <button
+        type="button"
+        onClick={onGoogleAuth}
+        className="flex w-full items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2.5 text-sm font-medium text-ssa-black transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-ssa-red focus:ring-offset-2"
+      >
+        <FcGoogle className="h-5 w-5" aria-hidden="true" />
+        {isGoogleSignup
+          ? 'Use a different Google account'
+          : 'Continue with Google'}
+      </button>
+
+      {isGoogleSignup && (
+        <div className="rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">
+          Google account connected for {data.email}.
+        </div>
+      )}
+
+      {!isGoogleSignup && (
+        <div className="flex items-center gap-3">
+          <div className="h-px flex-1 bg-ssa-red/40" />
+          <span className="text-xs font-medium uppercase tracking-wide text-ssa-black/60">
+            or
+          </span>
+          <div className="h-px flex-1 bg-ssa-red/40" />
+        </div>
+      )}
+
+      <InputField
+        label="Email Address"
+        required
+        name="email"
+        autoComplete="email"
+        placeholder="hello@gmail.com"
+        type="email"
+        value={data.email}
+        onChange={(v) => onChange('email', v)}
+        error={fieldErrors.email}
+        readOnly={isGoogleSignup}
+      />
+      {!isGoogleSignup && (
+        <>
+          <InputField
+            label="Password"
+            required
+            name="password"
+            autoComplete="new-password"
+            placeholder="Min. 8 characters, include a letter and number"
+            type="password"
+            value={data.password}
+            onChange={(v) => onChange('password', v)}
+            error={fieldErrors.password}
+          />
+          <InputField
+            label="Confirm Password"
+            required
+            name="confirmPassword"
+            autoComplete="new-password"
+            placeholder="Re-enter password"
+            type="password"
+            value={data.confirmPassword}
+            onChange={(v) => onChange('confirmPassword', v)}
+            error={fieldErrors.confirmPassword}
+          />
+        </>
+      )}
+
+      {isGoogleSignup && (
+        <button
+          type="button"
+          onClick={onUseEmailAuth}
+          className="self-start text-sm font-medium text-ssa-red underline-offset-4 hover:underline"
+        >
+          Use email and password instead
+        </button>
+      )}
+    </CardSection>
+  )
+}

--- a/web/src/app/signup/_components/ContactStep.tsx
+++ b/web/src/app/signup/_components/ContactStep.tsx
@@ -36,17 +36,6 @@ export default function ContactStep({
         />
       </div>
       <InputField
-        label="Email Address"
-        required
-        name="email"
-        autoComplete="email"
-        placeholder="hello@gmail.com"
-        type="email"
-        value={data.email}
-        onChange={(v) => onChange('email', v)}
-        error={fieldErrors.email}
-      />
-      <InputField
         label="Phone Number"
         required
         name="phone"
@@ -56,28 +45,6 @@ export default function ContactStep({
         value={data.phone}
         onChange={(v) => onChange('phone', v)}
         error={fieldErrors.phone}
-      />
-      <InputField
-        label="Password"
-        required
-        name="password"
-        autoComplete="new-password"
-        placeholder="Min. 8 characters, include a letter and number"
-        type="password"
-        value={data.password}
-        onChange={(v) => onChange('password', v)}
-        error={fieldErrors.password}
-      />
-      <InputField
-        label="Confirm Password"
-        required
-        name="confirmPassword"
-        autoComplete="new-password"
-        placeholder="Re-enter password"
-        type="password"
-        value={data.confirmPassword}
-        onChange={(v) => onChange('confirmPassword', v)}
-        error={fieldErrors.confirmPassword}
       />
     </CardSection>
   )

--- a/web/src/app/signup/_components/SignupForm.tsx
+++ b/web/src/app/signup/_components/SignupForm.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { TOTAL_STEPS, initialFormData, type FormData } from './types'
 import ProgressBar from '@/components/ProgressBar'
+import AccountSignUpStep from './AccountSignUpStep'
 import ContactStep from './ContactStep'
 import UniInfoStep from './UniInfoStep'
 import AdditionalInfoStep from './AdditionalInfoStep'
@@ -12,12 +13,82 @@ import PaymentStep from '@/components/PaymentStep'
 export default function SignupForm() {
   const searchParams = useSearchParams()
   const wasCancelled = searchParams.get('cancelled') === 'true'
+  const googleStatus = searchParams.get('google')
+  const googleConnectionError =
+    googleStatus && googleStatus !== 'connected'
+      ? 'Google sign up could not be completed. Please try again.'
+      : null
 
   const [step, setStep] = useState(1)
   const [formData, setFormData] = useState<FormData>(initialFormData)
+  const [isCheckingEmail, setIsCheckingEmail] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (!googleStatus) return
+
+    if (googleStatus !== 'connected') return
+
+    let isActive = true
+
+    async function loadGoogleProfile() {
+      try {
+        const response = await fetch('/api/auth/google/session')
+        const result = (await response.json()) as {
+          profile?: {
+            email?: string
+            firstName?: string
+            googleSub?: string
+            lastName?: string
+          }
+        }
+
+        if (!isActive) return
+
+        if (
+          !response.ok ||
+          !result.profile?.email ||
+          !result.profile.googleSub
+        ) {
+          setError(
+            'Google sign up session expired. Please connect Google again.',
+          )
+          return
+        }
+
+        setFormData((prev) => ({
+          ...prev,
+          authProvider: 'google',
+          email: result.profile?.email ?? '',
+          firstName: prev.firstName || result.profile?.firstName || '',
+          googleSub: result.profile?.googleSub ?? '',
+          lastName: prev.lastName || result.profile?.lastName || '',
+          password: '',
+          confirmPassword: '',
+        }))
+        setFieldErrors((prev) => {
+          const next = { ...prev }
+          delete next.email
+          delete next.password
+          delete next.confirmPassword
+          return next
+        })
+        setError(null)
+      } catch {
+        if (isActive) {
+          setError('Google sign up could not be loaded. Please try again.')
+        }
+      }
+    }
+
+    loadGoogleProfile()
+
+    return () => {
+      isActive = false
+    }
+  }, [googleStatus])
 
   function handleChange(field: keyof FormData, value: string) {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -32,26 +103,33 @@ export default function SignupForm() {
   function validateStep(s: number): Record<string, string> {
     const errors: Record<string, string> = {}
     if (s === 1) {
-      if (!formData.firstName.trim())
-        errors.firstName = 'First name is required'
-      if (!formData.lastName.trim()) errors.lastName = 'Last name is required'
       if (
         !formData.email.trim() ||
         !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)
       ) {
         errors.email = 'Valid email is required'
       }
-      if (!formData.phone.trim()) errors.phone = 'Phone number is required'
-      if (
-        formData.password.length < 8 ||
-        !/[a-zA-Z]/.test(formData.password) ||
-        !/[0-9]/.test(formData.password)
-      )
-        errors.password =
-          'Password must be at least 8 characters and include a letter and a number'
-      if (formData.password !== formData.confirmPassword)
-        errors.confirmPassword = 'Passwords do not match'
+      if (formData.authProvider === 'google') {
+        if (!formData.googleSub) {
+          errors.email = 'Please connect your Google account again'
+        }
+      } else {
+        if (
+          formData.password.length < 8 ||
+          !/[a-zA-Z]/.test(formData.password) ||
+          !/[0-9]/.test(formData.password)
+        )
+          errors.password =
+            'Password must be at least 8 characters and include a letter and a number'
+        if (formData.password !== formData.confirmPassword)
+          errors.confirmPassword = 'Passwords do not match'
+      }
     } else if (s === 2) {
+      if (!formData.firstName.trim())
+        errors.firstName = 'First name is required'
+      if (!formData.lastName.trim()) errors.lastName = 'Last name is required'
+      if (!formData.phone.trim()) errors.phone = 'Phone number is required'
+    } else if (s === 3) {
       if (!formData.upi.trim()) errors.upi = 'UPI is required'
       if (!formData.studentId.trim())
         errors.studentId = 'Student ID is required'
@@ -59,7 +137,7 @@ export default function SignupForm() {
         errors.areaOfStudy = 'Area of study is required'
       if (!formData.yearOfUniversity)
         errors.yearOfUniversity = 'Year of university is required'
-    } else if (s === 3) {
+    } else if (s === 4) {
       if (!formData.gender) errors.gender = 'Gender is required'
       if (!formData.ethnicity) errors.ethnicity = 'Ethnicity is required'
       if (!formData.returningMember)
@@ -68,12 +146,47 @@ export default function SignupForm() {
     return errors
   }
 
-  function handleNext() {
+  async function checkEmailAvailability() {
+    setIsCheckingEmail(true)
+    try {
+      const response = await fetch('/api/signup/check-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: formData.email }),
+      })
+      const result = (await response.json()) as {
+        available?: boolean
+        error?: string
+      }
+
+      if (!response.ok || result.available === false) {
+        const message = result.error ?? 'This email is already registered'
+        setFieldErrors((prev) => ({ ...prev, email: message }))
+        return false
+      }
+
+      return true
+    } catch {
+      setError('Could not check this email. Please try again.')
+      return false
+    } finally {
+      setIsCheckingEmail(false)
+    }
+  }
+
+  async function handleNext() {
     const errors = validateStep(step)
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors)
       return
     }
+
+    if (step === 1) {
+      setError(null)
+      const isEmailAvailable = await checkEmailAvailability()
+      if (!isEmailAvailable) return
+    }
+
     setFieldErrors({})
     if (step < TOTAL_STEPS) setStep((s) => s + 1)
   }
@@ -82,21 +195,42 @@ export default function SignupForm() {
     if (step > 1) setStep((s) => s - 1)
   }
 
+  function handleGoogleAuth() {
+    window.location.href = '/api/auth/google'
+  }
+
+  function handleUseEmailAuth() {
+    fetch('/api/auth/google/session', { method: 'DELETE' }).catch(() => {})
+    setFormData((prev) => ({
+      ...prev,
+      authProvider: 'email',
+      googleSub: '',
+    }))
+  }
+
   const handlePay = async () => {
     setError(null)
 
     const step1Errors = validateStep(1)
     const step2Errors = validateStep(2)
     const step3Errors = validateStep(3)
-    const allErrors = { ...step1Errors, ...step2Errors, ...step3Errors }
+    const step4Errors = validateStep(4)
+    const allErrors = {
+      ...step1Errors,
+      ...step2Errors,
+      ...step3Errors,
+      ...step4Errors,
+    }
     if (Object.keys(allErrors).length > 0) {
       setFieldErrors(allErrors)
       if (Object.keys(step1Errors).length > 0) {
         setStep(1)
       } else if (Object.keys(step2Errors).length > 0) {
         setStep(2)
-      } else {
+      } else if (Object.keys(step3Errors).length > 0) {
         setStep(3)
+      } else {
+        setStep(4)
       }
       return
     }
@@ -107,8 +241,12 @@ export default function SignupForm() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          firstName: formData.firstName,
+          lastName: formData.lastName,
           name: `${formData.firstName} ${formData.lastName}`,
+          authProvider: formData.authProvider,
           email: formData.email,
+          googleSub: formData.googleSub,
           password: formData.password,
           phone: formData.phone,
           upi: formData.upi,
@@ -124,7 +262,13 @@ export default function SignupForm() {
       const result = await response.json()
 
       if (!response.ok || !result.checkoutUrl) {
-        setError(result.error ?? 'Something went wrong. Please try again.')
+        const message =
+          result.error ?? 'Something went wrong. Please try again.'
+        setError(message)
+        if (response.status === 409) {
+          setFieldErrors((prev) => ({ ...prev, email: message }))
+          setStep(1)
+        }
         return
       }
 
@@ -146,36 +290,45 @@ export default function SignupForm() {
             </div>
           )}
 
-          {error && (
+          {(error || googleConnectionError) && (
             <div className="rounded-lg bg-red-50 border border-red-200 p-3 text-red-800 text-sm">
-              {error}
+              {error || googleConnectionError}
             </div>
           )}
 
           <ProgressBar step={step} total={TOTAL_STEPS} />
 
           {step === 1 && (
+            <AccountSignUpStep
+              data={formData}
+              onChange={handleChange}
+              fieldErrors={fieldErrors}
+              onGoogleAuth={handleGoogleAuth}
+              onUseEmailAuth={handleUseEmailAuth}
+            />
+          )}
+          {step === 2 && (
             <ContactStep
               data={formData}
               onChange={handleChange}
               fieldErrors={fieldErrors}
             />
           )}
-          {step === 2 && (
+          {step === 3 && (
             <UniInfoStep
               data={formData}
               onChange={handleChange}
               fieldErrors={fieldErrors}
             />
           )}
-          {step === 3 && (
+          {step === 4 && (
             <AdditionalInfoStep
               data={formData}
               onChange={handleChange}
               fieldErrors={fieldErrors}
             />
           )}
-          {step === 4 && (
+          {step === 5 && (
             <PaymentStep onPay={handlePay} isLoading={isLoading} />
           )}
 
@@ -193,9 +346,10 @@ export default function SignupForm() {
             {step < TOTAL_STEPS && (
               <button
                 onClick={handleNext}
-                className="px-6 py-2 rounded-full bg-ssa-red text-sm font-medium text-white"
+                disabled={isCheckingEmail}
+                className="px-6 py-2 rounded-full bg-ssa-red text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Next
+                {isCheckingEmail ? 'Checking...' : 'Next'}
               </button>
             )}
           </div>

--- a/web/src/app/signup/_components/types.ts
+++ b/web/src/app/signup/_components/types.ts
@@ -1,9 +1,11 @@
-export const TOTAL_STEPS = 4
+export const TOTAL_STEPS = 5
 
 export type FormData = {
+  authProvider: 'email' | 'google'
   firstName: string
   lastName: string
   email: string
+  googleSub: string
   phone: string
   password: string
   confirmPassword: string
@@ -17,9 +19,11 @@ export type FormData = {
 }
 
 export const initialFormData: FormData = {
+  authProvider: 'email',
   firstName: '',
   lastName: '',
   email: '',
+  googleSub: '',
   phone: '',
   password: '',
   confirmPassword: '',

--- a/web/src/app/signup/success/page.tsx
+++ b/web/src/app/signup/success/page.tsx
@@ -4,26 +4,56 @@ interface Props {
   searchParams: Promise<{ session_id?: string }>
 }
 
+type ConfirmationResult = 'confirmed' | 'pending' | 'unavailable' | 'missing'
+
+async function confirmCheckoutSession(
+  sessionId?: string,
+): Promise<ConfirmationResult> {
+  if (!sessionId) return 'missing'
+
+  const cmsUrl = process.env.CMS_URL
+  if (!cmsUrl) return 'unavailable'
+
+  try {
+    const response = await fetch(
+      `${cmsUrl}/stripe/checkout/confirm?session_id=${encodeURIComponent(sessionId)}`,
+      { cache: 'no-store' },
+    )
+
+    if (!response.ok) return 'unavailable'
+
+    const result = (await response.json()) as {
+      confirmed?: boolean
+    }
+
+    return result.confirmed ? 'confirmed' : 'pending'
+  } catch {
+    return 'unavailable'
+  }
+}
+
 export default async function SignupSuccessPage({ searchParams }: Props) {
   const params = await searchParams
-  const hasSession = Boolean(params.session_id)
+  const confirmation = await confirmCheckoutSession(params.session_id)
+
+  const messageByConfirmation: Record<ConfirmationResult, string> = {
+    confirmed:
+      'Your payment has been confirmed and your SSA membership is now active.',
+    pending:
+      'We received your signup and are confirming your payment details. Your membership will be activated once confirmation is complete.',
+    unavailable:
+      'Your payment was completed, but we could not confirm it automatically. Please check your email for updates.',
+    missing:
+      'If you completed your payment, your membership will be activated shortly.',
+  }
 
   return (
     <main className="flex min-h-screen items-center justify-center p-8">
       <div className="w-full max-w-md text-center">
         <h1 className="font-averia font-bold text-3xl mb-3">Welcome to SSA!</h1>
-        {hasSession ? (
-          <p className="text-gray-600 mb-6">
-            We received your signup and are confirming your payment details.
-            Your membership will be activated once confirmation is complete.
-            Check your email for updates.
-          </p>
-        ) : (
-          <p className="text-gray-600 mb-6">
-            If you completed your payment, your membership will be activated
-            shortly.
-          </p>
-        )}
+        <p className="text-gray-600 mb-6">
+          {messageByConfirmation[confirmation]}
+        </p>
         <Link
           href="/"
           className="inline-block rounded-lg bg-ssa-red px-6 py-3 text-sm font-semibold text-white hover:opacity-90 transition-opacity"

--- a/web/src/components/InputField.tsx
+++ b/web/src/components/InputField.tsx
@@ -11,7 +11,9 @@ export default function InputField({
   type = 'text',
   error,
   autoComplete,
+  disabled,
   name,
+  readOnly,
 }: {
   label: string
   required?: boolean
@@ -21,7 +23,9 @@ export default function InputField({
   type?: string
   error?: string
   autoComplete?: string
+  disabled?: boolean
   name?: string
+  readOnly?: boolean
 }) {
   const id = useId()
   const errorId = useId()
@@ -42,6 +46,8 @@ export default function InputField({
         aria-invalid={!!error}
         aria-describedby={error ? errorId : undefined}
         autoComplete={autoComplete}
+        disabled={disabled}
+        readOnly={readOnly}
         className="w-full rounded-lg px-3 py-2 text-sm text-gray-900 outline-none border border-transparent focus:border-ssa-red bg-white placeholder:text-gray-400"
       />
       {error && (

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -12,7 +12,7 @@ const navLinks = [
   { label: 'Sponsors', href: '/sponsors' },
 ]
 
-const ctaLink = { label: 'Join SSA!', href: '/contact' }
+const ctaLink = { label: 'Join SSA!', href: '/signup' }
 
 export default function Navbar() {
   const [hidden, setHidden] = useState(false)

--- a/web/src/lib/googleSignupSession.ts
+++ b/web/src/lib/googleSignupSession.ts
@@ -1,0 +1,81 @@
+import crypto from 'crypto'
+
+export type GoogleSignupProfile = {
+  email: string
+  firstName?: string
+  googleSub: string
+  lastName?: string
+  name?: string
+}
+
+export const googleSignupSessionCookie = 'ssa_google_signup'
+export const googleOAuthStateCookie = 'ssa_google_oauth_state'
+
+const sessionVersion = 'v1'
+
+function getCookieSecret() {
+  const secret =
+    process.env.GOOGLE_OAUTH_COOKIE_SECRET || process.env.AUTH_SECRET
+
+  if (!secret) {
+    throw new Error('GOOGLE_OAUTH_COOKIE_SECRET must be configured')
+  }
+
+  return secret
+}
+
+function sign(value: string) {
+  return crypto
+    .createHmac('sha256', getCookieSecret())
+    .update(value)
+    .digest('base64url')
+}
+
+function timingSafeEqual(a: string, b: string) {
+  const aBuffer = Buffer.from(a)
+  const bBuffer = Buffer.from(b)
+
+  return (
+    aBuffer.length === bBuffer.length &&
+    crypto.timingSafeEqual(aBuffer, bBuffer)
+  )
+}
+
+export function createGoogleSignupSession(profile: GoogleSignupProfile) {
+  const payload = Buffer.from(JSON.stringify(profile)).toString('base64url')
+  const signedPayload = `${sessionVersion}.${payload}`
+
+  return `${signedPayload}.${sign(signedPayload)}`
+}
+
+export function readGoogleSignupSession(value?: null | string) {
+  if (!value) return null
+
+  const [version, payload, signature] = value.split('.')
+  if (version !== sessionVersion || !payload || !signature) return null
+
+  const signedPayload = `${version}.${payload}`
+  if (!timingSafeEqual(signature, sign(signedPayload))) return null
+
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(payload, 'base64url').toString('utf8'),
+    ) as Partial<GoogleSignupProfile>
+
+    if (!parsed.email || !parsed.googleSub) return null
+
+    return {
+      email: parsed.email,
+      firstName: parsed.firstName,
+      googleSub: parsed.googleSub,
+      lastName: parsed.lastName,
+      name: parsed.name,
+    } satisfies GoogleSignupProfile
+  } catch {
+    return null
+  }
+}
+
+export function createOAuthState() {
+  return crypto.randomBytes(24).toString('base64url')
+}


### PR DESCRIPTION
## What does this PR do?

Implements the full paid signup flow across the web app and Payload CMS.

Changes include:

- Splits signup into a dedicated account step and contact info step.
- Adds `AccountSignUpStep` with email/password signup and Google OAuth signup.
- Removes email/password fields from the contact step, leaving first name, last name, and phone number.
- Adds Google OAuth routes:
  - OAuth start route
  - OAuth callback route
  - Google signup session route
- Stores Google signup identity in a signed httpOnly cookie.
- Adds Google OAuth support to checkout using verified server-side session data.
- Adds Stripe checkout redirect support.
- Creates/reuses Stripe customers using the signup email.
- Redirects successful payments to the signup success page.
- Confirms Stripe checkout sessions after payment.
- Adds paid members to the Payload `users` collection after successful payment.
- Expands Payload `users` and `members` fields with signup data:
  - name
  - first name
  - last name
  - phone
  - membership status
  - membership expiry date
  - Stripe customer ID
  - UPI
  - student ID
  - area of study
  - year of university
  - gender
  - ethnicity
  - returning member
  - auth provider
  - Google subject ID
- Adds password encryption for temporary signup passwords before payment confirmation.
- Adds duplicate email checks before continuing signup and before Stripe checkout.
- Adds web and CMS email availability routes.
- Updates README docs for required Google OAuth environment variables.
- Fixes lint issue from synchronous state updates inside signup effects.
- Updates generated Payload types/import map.

Google OAuth setup for local testing:
1. Go to Google Cloud Console: https://console.cloud.google.com/
2. Select the project used for this OAuth app (SSA Website).
3. Navigate to APIs and Services
4. Navigate to OAuth Consent Screen shown in the left hand side panel.
5. Click Audience in the left hand side panel
6. Scroll down to Test Users
7. Click **Add users**.
8. Add the Gmail address you want to test with.
9. Save changes.

Note: There is no button that actually leads to the sign-up form, so you have to manually enter localhost:3000/signup in the URL bar. 

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Chore / config
- [ ] Hotfix

## Checklist

- [x] My branch follows the naming convention (`feature/`, `fix/`, `chore/`, `hotfix/`)
- [x] My commit messages follow the conventional commits format
- [x] CI checks pass

## Linked Issues
Closes #
Addresses #
Related to #
