### PR TITLE
feat: reusable animated Button component (#117)

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
         subtitle="A home for people from the Little Red Dot."
         mascotImage="/ssa_merlion_full_body.svg"
         mascotAlt="SSA Merlion mascot"
-        ctaLabel="Join Us!"
+        ctaLabel="JOIN SSA!"
         ctaHref="/signup"
         showSingaporeFlag
       />

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
         subtitle="A home for people from the Little Red Dot."
         mascotImage="/ssa_merlion_full_body.svg"
         mascotAlt="SSA Merlion mascot"
-        ctaLabel="Join Us! →"
+        ctaLabel="Join Us!"
         ctaHref="/signup"
         showSingaporeFlag
       />

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type React from 'react'
-import { FaArrowRight } from 'react-icons/fa6'
+import { FiArrowRight } from 'react-icons/fi'
 
 export type ButtonSize = 'short' | 'long'
 export type ButtonVariant = 'filled' | 'light' | 'outline'
@@ -23,11 +23,25 @@ export type ArrowSide = 'left' | 'right'
  */
 
 const base =
-  'group relative inline-flex items-center justify-center overflow-hidden rounded-full font-averia font-bold leading-tight cursor-pointer select-none transition-all duration-300 ease-out shadow-[0_3px_0_0_rgba(0,0,0,0.08)] hover:-translate-y-0.5 hover:shadow-[0_5px_0_0_rgba(0,0,0,0.08)] active:translate-y-0 active:shadow-[0_2px_0_0_rgba(0,0,0,0.08)] focus:outline-none focus:ring-2 focus:ring-ssa-muted-gold focus:ring-offset-2 disabled:opacity-60 disabled:pointer-events-none'
+  'group relative inline-flex items-center justify-center overflow-hidden rounded-full font-sans font-bold leading-tight cursor-pointer select-none transition-all duration-300 ease-out shadow-[0_3px_0_0_rgba(0,0,0,0.08)] hover:-translate-y-0.5 hover:shadow-[0_5px_0_0_rgba(0,0,0,0.08)] active:translate-y-0 active:shadow-[0_2px_0_0_rgba(0,0,0,0.08)] focus:outline-none focus:ring-2 focus:ring-ssa-muted-gold focus:ring-offset-2 disabled:opacity-60 disabled:pointer-events-none'
 
 const sizes: Record<ButtonSize, string> = {
-  short: 'px-10 py-2.5 text-base md:px-11 md:py-3 md:text-lg',
-  long: 'w-full px-12 py-3.5 text-lg',
+  short: 'py-2.5 text-base md:py-3 md:text-lg',
+  long: 'w-full py-3.5 text-lg',
+}
+
+// Horizontal metrics, in `em` so they track the label size instead of needing a
+// responsive override per breakpoint:
+//   inset (2.2em)    — edge gap, and the slot both arrows sit in
+//   reserve (1.8em)  — arrow width (1.2em) + gap to the label (0.6em)
+// The arrow's side is padded by inset + reserve, so at rest the label starts flush
+// against the empty slot the incoming arrow will land in, and the label + arrow read
+// as one centred group. On hover the label slides across by exactly `reserve`,
+// landing mirrored as the arrows swap sides.
+const padX: Record<ArrowSide | 'none', string> = {
+  right: 'pl-[2.2em] pr-[4em]',
+  left: 'pl-[4em] pr-[2.2em]',
+  none: 'px-[2.2em]',
 }
 
 // Colour treatments — background + text colours swap on hover. Full literal class
@@ -54,7 +68,7 @@ const treatments: Record<ButtonVariant, Record<ButtonColor, string>> = {
 }
 
 const arrowBase =
-  'pointer-events-none absolute top-1/2 h-[0.9em] w-[0.9em] -translate-y-1/2 transition-all duration-300 ease-out'
+  'pointer-events-none absolute top-1/2 h-[1.2em] w-[1.2em] -translate-y-1/2 transition-all duration-300 ease-out'
 
 // Per starting-side motion: which slot the arrow occupies by default, where it
 // animates on hover, and how the label slides. `leftSlot`/`rightSlot` are the two
@@ -65,17 +79,19 @@ const arrowMotion: Record<
 > = {
   // Arrow starts on the right; on hover it slides all the way off the right edge
   // while a fresh arrow slides in from off the left edge (overflow-hidden clips
-  // both ends, so they travel rather than fade).
+  // both ends, so they travel rather than fade). Both slots rest at the 2.2em inset;
+  // 4em of travel clears the inset plus the arrow's own width. The label shifts by
+  // `reserve` (1.8em), so it ends up flush against the arrow's vacated side.
   right: {
-    leftSlot: 'left-6 -translate-x-16 group-hover:translate-x-0',
-    rightSlot: 'right-6 translate-x-0 group-hover:translate-x-16',
-    text: 'transition-transform duration-300 ease-out group-hover:translate-x-2',
+    leftSlot: 'left-[2.2em] -translate-x-[4em] group-hover:translate-x-0',
+    rightSlot: 'right-[2.2em] translate-x-0 group-hover:translate-x-[4em]',
+    text: 'transition-transform duration-300 ease-out group-hover:translate-x-[1.8em]',
   },
   // Mirror: arrow starts on the left, slides off the left, new one enters from the right.
   left: {
-    leftSlot: 'left-6 translate-x-0 group-hover:-translate-x-16',
-    rightSlot: 'right-6 translate-x-16 group-hover:translate-x-0',
-    text: 'transition-transform duration-300 ease-out group-hover:-translate-x-2',
+    leftSlot: 'left-[2.2em] translate-x-0 group-hover:-translate-x-[4em]',
+    rightSlot: 'right-[2.2em] translate-x-[4em] group-hover:translate-x-0',
+    text: 'transition-transform duration-300 ease-out group-hover:-translate-x-[1.8em]',
   },
 }
 
@@ -113,7 +129,18 @@ export default function Button({
   className = '',
   ...props
 }: ButtonProps) {
-  const classes = [base, sizes[size], treatments[variant][color], className]
+  // A `long` button is full-width, so the arrow parks far from the label and the
+  // mirror reading doesn't apply — keep the padding even so the label stays centred
+  // in the bar, as with an arrowless button.
+  const padding = size === 'long' || !arrow ? padX.none : padX[arrowSide]
+
+  const classes = [
+    base,
+    sizes[size],
+    padding,
+    treatments[variant][color],
+    className,
+  ]
     .filter(Boolean)
     .join(' ')
 
@@ -121,14 +148,14 @@ export default function Button({
   const content = (
     <>
       {arrow && (
-        <FaArrowRight
+        <FiArrowRight
           aria-hidden
           className={`${arrowBase} ${motion.leftSlot}`}
         />
       )}
       <span className={arrow ? motion.text : undefined}>{children}</span>
       {arrow && (
-        <FaArrowRight
+        <FiArrowRight
           aria-hidden
           className={`${arrowBase} ${motion.rightSlot}`}
         />

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -96,10 +96,10 @@ type ButtonElementProps = CommonProps &
     href?: undefined
   }
 
+// Derive link props from `next/link` so callers keep Next features
+// (prefetch/replace/scroll and the UrlObject `href` form).
 type LinkElementProps = CommonProps &
-  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof CommonProps> & {
-    href: string
-  }
+  Omit<React.ComponentProps<typeof Link>, keyof CommonProps>
 
 export type ButtonProps = ButtonElementProps | LinkElementProps
 

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -25,23 +25,14 @@ export type ArrowSide = 'left' | 'right'
 const base =
   'group relative inline-flex items-center justify-center overflow-hidden rounded-full font-sans font-bold leading-tight cursor-pointer select-none transition-all duration-300 ease-out shadow-[0_3px_0_0_rgba(0,0,0,0.08)] hover:-translate-y-0.5 hover:shadow-[0_5px_0_0_rgba(0,0,0,0.08)] active:translate-y-0 active:shadow-[0_2px_0_0_rgba(0,0,0,0.08)] focus:outline-none focus:ring-2 focus:ring-ssa-muted-gold focus:ring-offset-2 disabled:opacity-60 disabled:pointer-events-none'
 
+// Horizontal metrics are in `em` so they track the label size instead of needing a
+// responsive override per breakpoint. `px-[2.2em]` is the edge inset — for `short` it
+// sets the pill's width, for `long` it's just a floor. The arrow's own room is
+// reserved inside the label group (see `arrowMotion.reserve`), not against the pill
+// edges, so the label + arrow stay centred together at any pill width.
 const sizes: Record<ButtonSize, string> = {
-  short: 'py-2.5 text-base md:py-3 md:text-lg',
-  long: 'w-full py-3.5 text-lg',
-}
-
-// Horizontal metrics, in `em` so they track the label size instead of needing a
-// responsive override per breakpoint:
-//   inset (2.2em)    — edge gap, and the slot both arrows sit in
-//   reserve (1.8em)  — arrow width (1.2em) + gap to the label (0.6em)
-// The arrow's side is padded by inset + reserve, so at rest the label starts flush
-// against the empty slot the incoming arrow will land in, and the label + arrow read
-// as one centred group. On hover the label slides across by exactly `reserve`,
-// landing mirrored as the arrows swap sides.
-const padX: Record<ArrowSide | 'none', string> = {
-  right: 'pl-[2.2em] pr-[4em]',
-  left: 'pl-[4em] pr-[2.2em]',
-  none: 'px-[2.2em]',
+  short: 'px-[2.2em] py-2.5 text-base md:py-3 md:text-lg',
+  long: 'w-full px-[2.2em] py-3.5 text-lg',
 }
 
 // Colour treatments — background + text colours swap on hover. Full literal class
@@ -67,30 +58,40 @@ const treatments: Record<ButtonVariant, Record<ButtonColor, string>> = {
   },
 }
 
-const arrowBase =
-  'pointer-events-none absolute top-1/2 h-[1.2em] w-[1.2em] -translate-y-1/2 transition-all duration-300 ease-out'
+// The label and both arrow slots live in a wrapper that hugs them, so the whole group
+// centres as one unit — a `long` button looks like a `short` one, just wider.
+const arrowGroup = 'relative inline-flex items-center'
 
-// Per starting-side motion: which slot the arrow occupies by default, where it
-// animates on hover, and how the label slides. `leftSlot`/`rightSlot` are the two
-// absolute arrow elements; `text` shifts the label toward the vacated side.
+// One arrow slot: a fixed 1.2em window pinned to an edge of the group. The window
+// clips its icon, so an arrow sliding out wipes away at the label's edge rather than
+// having to travel to the pill's edge — a distance that varies with pill width and
+// would leave the arrow popping in mid-bar on a full-width button.
+const arrowSlot =
+  'pointer-events-none absolute top-1/2 h-[1.2em] w-[1.2em] -translate-y-1/2 overflow-hidden'
+const arrowIcon = 'h-full w-full transition-transform duration-300 ease-out'
+
+// Per starting-side motion. `reserve` is the room the arrow needs inside the group —
+// its 1.2em width plus a 0.6em gap to the label — so at rest the label sits flush
+// against the empty slot the incoming arrow will land in. `leftIcon`/`rightIcon` slide
+// each icon out of its own window by exactly its width (`translate-x-full`). `text`
+// shifts the label across by `reserve`, landing it mirrored as the arrows swap sides.
 const arrowMotion: Record<
   ArrowSide,
-  { leftSlot: string; rightSlot: string; text: string }
+  { reserve: string; leftIcon: string; rightIcon: string; text: string }
 > = {
-  // Arrow starts on the right; on hover it slides all the way off the right edge
-  // while a fresh arrow slides in from off the left edge (overflow-hidden clips
-  // both ends, so they travel rather than fade). Both slots rest at the 2.2em inset;
-  // 4em of travel clears the inset plus the arrow's own width. The label shifts by
-  // `reserve` (1.8em), so it ends up flush against the arrow's vacated side.
+  // Arrow starts on the right; on hover it wipes out to the right while a fresh arrow
+  // wipes in on the left and the label slides right to fill the vacated space.
   right: {
-    leftSlot: 'left-[2.2em] -translate-x-[4em] group-hover:translate-x-0',
-    rightSlot: 'right-[2.2em] translate-x-0 group-hover:translate-x-[4em]',
+    reserve: 'pr-[1.8em]',
+    leftIcon: '-translate-x-full group-hover:translate-x-0',
+    rightIcon: 'translate-x-0 group-hover:translate-x-full',
     text: 'transition-transform duration-300 ease-out group-hover:translate-x-[1.8em]',
   },
-  // Mirror: arrow starts on the left, slides off the left, new one enters from the right.
+  // Mirror: arrow starts on the left, wipes out left, new one wipes in on the right.
   left: {
-    leftSlot: 'left-[2.2em] translate-x-0 group-hover:-translate-x-[4em]',
-    rightSlot: 'right-[2.2em] translate-x-[4em] group-hover:translate-x-0',
+    reserve: 'pl-[1.8em]',
+    leftIcon: 'translate-x-0 group-hover:-translate-x-full',
+    rightIcon: 'translate-x-full group-hover:translate-x-0',
     text: 'transition-transform duration-300 ease-out group-hover:-translate-x-[1.8em]',
   },
 }
@@ -129,38 +130,29 @@ export default function Button({
   className = '',
   ...props
 }: ButtonProps) {
-  // A `long` button is full-width, so the arrow parks far from the label and the
-  // mirror reading doesn't apply — keep the padding even so the label stays centred
-  // in the bar, as with an arrowless button.
-  const padding = size === 'long' || !arrow ? padX.none : padX[arrowSide]
-
-  const classes = [
-    base,
-    sizes[size],
-    padding,
-    treatments[variant][color],
-    className,
-  ]
+  const classes = [base, sizes[size], treatments[variant][color], className]
     .filter(Boolean)
     .join(' ')
 
   const motion = arrowMotion[arrowSide]
-  const content = (
-    <>
-      {arrow && (
+  const content = arrow ? (
+    <span className={`${arrowGroup} ${motion.reserve}`}>
+      <span className={`${arrowSlot} left-0`}>
         <FiArrowRight
           aria-hidden
-          className={`${arrowBase} ${motion.leftSlot}`}
+          className={`${arrowIcon} ${motion.leftIcon}`}
         />
-      )}
-      <span className={arrow ? motion.text : undefined}>{children}</span>
-      {arrow && (
+      </span>
+      <span className={motion.text}>{children}</span>
+      <span className={`${arrowSlot} right-0`}>
         <FiArrowRight
           aria-hidden
-          className={`${arrowBase} ${motion.rightSlot}`}
+          className={`${arrowIcon} ${motion.rightIcon}`}
         />
-      )}
-    </>
+      </span>
+    </span>
+  ) : (
+    <span>{children}</span>
   )
 
   if (props.href !== undefined) {

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,0 +1,154 @@
+import Link from 'next/link'
+import type React from 'react'
+import { FaArrowRight } from 'react-icons/fa6'
+
+export type ButtonSize = 'short' | 'long'
+export type ButtonVariant = 'filled' | 'light' | 'outline'
+export type ButtonColor = 'red' | 'yellow' | 'skin'
+export type ArrowSide = 'left' | 'right'
+
+/**
+ * Shared SSA pill button (matches the finalized "JOIN SSA!" Figma design).
+ *
+ * On hover the background and text colours swap, the label slides across, and the
+ * arrow animates to the opposite side of the button while the pill lifts.
+ *
+ * - `size`      — `short` (content width) or `long` (full-width CTA).
+ * - `variant`   — `filled` (accent fill, light text) · `light` (cream fill, accent text) · `outline`.
+ * - `color`     — accent token driving the colour so it can be changed via a prop.
+ * - `arrow`     — show the animated arrow (default `true`).
+ * - `arrowSide` — which side the arrow starts on; it moves to the opposite side on hover
+ *                 (default `right`: starts right → hover left; set `left` for the reverse).
+ * - `href`      — when set, renders a Next `Link`; otherwise a native `<button>`.
+ */
+
+const base =
+  'group relative inline-flex items-center justify-center overflow-hidden rounded-full font-averia font-bold leading-tight cursor-pointer select-none transition-all duration-300 ease-out shadow-[0_3px_0_0_rgba(0,0,0,0.08)] hover:-translate-y-0.5 hover:shadow-[0_5px_0_0_rgba(0,0,0,0.08)] active:translate-y-0 active:shadow-[0_2px_0_0_rgba(0,0,0,0.08)] focus:outline-none focus:ring-2 focus:ring-ssa-muted-gold focus:ring-offset-2 disabled:opacity-60 disabled:pointer-events-none'
+
+const sizes: Record<ButtonSize, string> = {
+  short: 'px-10 py-2.5 text-base md:px-11 md:py-3 md:text-lg',
+  long: 'w-full px-12 py-3.5 text-lg',
+}
+
+// Colour treatments — background + text colours swap on hover. Full literal class
+// strings so Tailwind can detect them.
+const treatments: Record<ButtonVariant, Record<ButtonColor, string>> = {
+  filled: {
+    red: 'bg-ssa-red text-ssa-white hover:bg-ssa-yellow-light hover:text-ssa-red',
+    yellow:
+      'bg-ssa-dark-skin-yellow text-ssa-cta-text hover:bg-ssa-yellow-light hover:text-ssa-muted-gold',
+    skin: 'bg-ssa-skin-yellow text-ssa-category-text hover:bg-ssa-dark-skin-yellow hover:text-ssa-cta-text',
+  },
+  light: {
+    red: 'bg-ssa-yellow-light text-ssa-red hover:bg-ssa-red hover:text-ssa-white',
+    yellow:
+      'bg-ssa-yellow-light text-ssa-muted-gold hover:bg-ssa-dark-skin-yellow hover:text-ssa-cta-text',
+    skin: 'bg-ssa-yellow-light text-ssa-category-text hover:bg-ssa-skin-yellow hover:text-ssa-cta-text',
+  },
+  outline: {
+    red: 'bg-transparent border-[3px] border-ssa-red text-ssa-red hover:bg-ssa-red hover:text-ssa-white',
+    yellow:
+      'bg-transparent border-[3px] border-ssa-dark-skin-yellow text-ssa-muted-gold hover:bg-ssa-dark-skin-yellow hover:text-ssa-white',
+    skin: 'bg-transparent border-[3px] border-ssa-dark-skin-yellow text-ssa-category-text hover:bg-ssa-skin-yellow hover:text-ssa-cta-text',
+  },
+}
+
+const arrowBase =
+  'pointer-events-none absolute top-1/2 h-[0.9em] w-[0.9em] -translate-y-1/2 transition-all duration-300 ease-out'
+
+// Per starting-side motion: which slot the arrow occupies by default, where it
+// animates on hover, and how the label slides. `leftSlot`/`rightSlot` are the two
+// absolute arrow elements; `text` shifts the label toward the vacated side.
+const arrowMotion: Record<
+  ArrowSide,
+  { leftSlot: string; rightSlot: string; text: string }
+> = {
+  // Arrow starts on the right; on hover it slides all the way off the right edge
+  // while a fresh arrow slides in from off the left edge (overflow-hidden clips
+  // both ends, so they travel rather than fade).
+  right: {
+    leftSlot: 'left-6 -translate-x-16 group-hover:translate-x-0',
+    rightSlot: 'right-6 translate-x-0 group-hover:translate-x-16',
+    text: 'transition-transform duration-300 ease-out group-hover:translate-x-2',
+  },
+  // Mirror: arrow starts on the left, slides off the left, new one enters from the right.
+  left: {
+    leftSlot: 'left-6 translate-x-0 group-hover:-translate-x-16',
+    rightSlot: 'right-6 translate-x-16 group-hover:translate-x-0',
+    text: 'transition-transform duration-300 ease-out group-hover:-translate-x-2',
+  },
+}
+
+type CommonProps = {
+  children: React.ReactNode
+  size?: ButtonSize
+  variant?: ButtonVariant
+  color?: ButtonColor
+  /** Show the animated arrow (default `true`). */
+  arrow?: boolean
+  /** Side the arrow starts on; moves to the opposite side on hover (default `right`). */
+  arrowSide?: ArrowSide
+  className?: string
+}
+
+type ButtonElementProps = CommonProps &
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof CommonProps> & {
+    href?: undefined
+  }
+
+type LinkElementProps = CommonProps &
+  Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof CommonProps> & {
+    href: string
+  }
+
+export type ButtonProps = ButtonElementProps | LinkElementProps
+
+export default function Button({
+  children,
+  size = 'short',
+  variant = 'filled',
+  color = 'red',
+  arrow = true,
+  arrowSide = 'right',
+  className = '',
+  ...props
+}: ButtonProps) {
+  const classes = [base, sizes[size], treatments[variant][color], className]
+    .filter(Boolean)
+    .join(' ')
+
+  const motion = arrowMotion[arrowSide]
+  const content = (
+    <>
+      {arrow && (
+        <FaArrowRight
+          aria-hidden
+          className={`${arrowBase} ${motion.leftSlot}`}
+        />
+      )}
+      <span className={arrow ? motion.text : undefined}>{children}</span>
+      {arrow && (
+        <FaArrowRight
+          aria-hidden
+          className={`${arrowBase} ${motion.rightSlot}`}
+        />
+      )}
+    </>
+  )
+
+  if (props.href !== undefined) {
+    const { href, ...rest } = props as LinkElementProps
+    return (
+      <Link href={href} className={classes} {...rest}>
+        {content}
+      </Link>
+    )
+  }
+
+  const { type = 'button', ...rest } = props as ButtonElementProps
+  return (
+    <button type={type} className={classes} {...rest}>
+      {content}
+    </button>
+  )
+}

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import Link from 'next/link'
+import Button from '@/components/Button'
 
 type HeroVariant = 'fullscreen' | 'compact'
 
@@ -98,12 +98,14 @@ export default function Hero({
           </ul>
         )}
         {ctaLabel && ctaHref && (
-          <Link
+          <Button
             href={ctaHref}
-            className="mt-3 inline-flex w-fit self-start min-w-0 items-center justify-center rounded-[15px] border-2 border-ssa-yellow-light px-7 py-2 font-averia text-base font-bold text-ssa-yellow-light hover:bg-white/20 sm:mt-4 sm:px-8 sm:py-2.5 sm:text-lg"
+            variant="light"
+            size="short"
+            className="mt-3 w-fit self-start sm:mt-4"
           >
             {ctaLabel}
-          </Link>
+          </Button>
         )}
       </div>
       {mascotImage && (


### PR DESCRIPTION
## Summary
Implements **UI Overhaul 08 – New buttons** (#117): a single reusable, animated `Button` component matching the finalized SSA "JOIN SSA!" design, replacing hand-styled inline pill buttons.

`web/src/components/Button.tsx` — typed, polymorphic (renders `<button>`, or a Next `<Link>` when `href` is set):

- **`variant`**: `filled` (accent fill, light text) · `light` (cream fill, accent text — used on the red hero) · `outline`
- **`color`**: `red` (default) · `yellow` · `skin` — colour is a prop, per the ticket
- **`size`**: `short` (content-width) · `long` (full-width CTA)
- **`arrow` / `arrowSide`**: animated arrow; `arrowSide` (`right` default / `left`) sets the starting side
- Uses the existing `font-averia` and `ssa-*` design tokens; CSS/Tailwind only (no new deps)

### Hover animation
- **Background + text colours swap** (e.g. cream/red ⇄ red/white)
- The **label slides** across
- The **arrow travels**: it slides fully off the leading edge while a fresh arrow slides in from the opposite edge (clipped by `overflow-hidden`) — a slide-through, not a fade
- Soft layered-depth lift

## Adoption
- `Hero.tsx` CTA now uses `<Button variant="light">` — reproduces the cream "Join Us! →" hero pill.
- Removed the now-duplicate literal `→` from the homepage `ctaLabel` in `page.tsx`.

## Verification
- Checked every variant × size × colour and both `arrowSide` directions in the browser; confirmed the colour-swap + slide-through arrow hover against the Figma prototype.
- `tsc --noEmit`, `eslint`, and `prettier --check` all pass.

Closes #117
